### PR TITLE
Remove pytest-runner from setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
     include_package_data=True,
     install_requires=[],
     tests_require=tests_require,
-    setup_requires=['pytest-runner'],
     extras_require={
         'test': tests_require,
         'dev': dev_require + tests_require + docs_require,


### PR DESCRIPTION
python setup.py sdist was hanging, and removing the above fixed the
problem -- not ideal, but for now will allow us to move on