### PR TITLE
Creation API

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
+exclude = docs
 max-line-length = 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,27 @@
 language: python
 python: 3.5
 
-before_cache:
-  - rm -rf $HOME/.cache/pip/log
-cache:
-  directories:
-    - $HOME/.cache/pip
+env:
+  - TOXENV=py35
+  - TOXENV=flake8
+
+before_install:
+  - source /etc/lsb-release
+  - echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee -a /etc/apt/sources.list.d/rethinkdb.list
+  - wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+  - sudo apt-get update -qq
 
 install:
-  - pip install -e .[test]
-  - pip install codecov
+  - sudo apt-get install rethinkdb
+  - pip install "git+https://github.com/bigchaindb/bigchaindb.git"
+  - pip install -U codecov tox
 
-script: py.test -v --cov
+before_script:
+  - rethinkdb --daemon
+  - bigchaindb -y configure
+  # Start BigchainDB in the background and ignore any output
+  - bigchaindb start >/dev/null 2>&1 &
+
+script: tox -e ${TOXENV}
 
 after_success: codecov

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -83,7 +83,7 @@ Ready to contribute? Here's how to set up `coalaip` for local development.
    the tests, including testing other Python versions with tox::
 
     $ flake8 coalaip tests
-    $ python setup.py test or py.test
+    $ python setup.py test or pytest
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.
@@ -114,4 +114,12 @@ Tips
 
 To run a subset of tests::
 
-$ py.test tests.test_coalaip
+$ pytest tests.test_coalaip
+
+To run tests with debugging::
+
+$ pytest -s
+
+To run tests and break on errors::
+
+$ pytest --pdb

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,7 @@
 History
 =======
 
-0.1.0 (2016-08-04)
-------------------
+0.0.1.dev1 (2016-08-xx)
+-----------------------
 
-* First release on PyPI.
+* Development (pre-alpha) release on PyPI.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ help:
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 
-
 clean-build: ## remove build artifacts
 	rm -fr build/
 	rm -fr dist/
@@ -51,18 +50,13 @@ lint: ## check style with flake8
 	flake8 coalaip tests
 
 test: ## run tests quickly with the default Python
-	py.test
+	py.test -v
 
+test-cov: ## run tests with coverage
+	py.test -v --cov=coalaip
 
 test-all: ## run tests on every Python version with tox
 	tox
-
-coverage: ## check code coverage quickly with the default Python
-	coverage run --source coalaip py.test
-
-		coverage report -m
-		coverage html
-		$(BROWSER) htmlcov/index.html
 
 docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/coalaip.rst
@@ -72,17 +66,15 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html
 
-servedocs: docs ## compile the docs watching for changes
-	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
-
-release: clean ## package and upload a release
-	python setup.py sdist upload
-	python setup.py bdist_wheel upload
+release: clean dist ## make ready-to-release package
+	@echo "\033[1mUse '$ twine upload dist/*' to release the package\033[0m"
 
 dist: clean ## builds source and wheel package
 	python setup.py sdist
 	python setup.py bdist_wheel
-	ls -l dist
+	@echo "\n--------Ready for release--------\n"
+	ls -d1 dist/*.*
+	@echo "\n---------------------------------\n"
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ lint: ## check style with flake8
 	flake8 coalaip tests
 
 test: ## run tests quickly with the default Python
-	py.test -v
+	pytest -v
 
 test-cov: ## run tests with coverage
-	py.test -v --cov=coalaip
+	pytest -v --cov=coalaip
 
 test-all: ## run tests on every Python version with tox
 	tox

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ pycoalaip
 Python reference implementation for COALA IP
 
 
+* Development Status: Pre-Alpha
 * Free software: Apache Software License 2.0
 * Documentation: https://pycoalaip.readthedocs.io.
 

--- a/coalaip/__init__.py
+++ b/coalaip/__init__.py
@@ -1,3 +1,11 @@
 __author__ = 'BigchainDB'
 __email__ = 'dev@bigchaindb.com'
 __version__ = '0.0.1.dev1'
+
+from coalaip.coalaip import (  # noqa
+    bind_plugin,
+    create_user,
+    register_manifestation,
+    derive_right,
+    transfer_right
+)

--- a/coalaip/__init__.py
+++ b/coalaip/__init__.py
@@ -3,9 +3,5 @@ __email__ = 'dev@bigchaindb.com'
 __version__ = '0.0.1.dev1'
 
 from coalaip.coalaip import (  # noqa
-    bind_plugin,
-    generate_user,
-    register_manifestation,
-    derive_right,
-    transfer_right
+    CoalaIp
 )

--- a/coalaip/__init__.py
+++ b/coalaip/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'BigchainDB'
 __email__ = 'dev@bigchaindb.com'
-__version__ = '0.1.0'
+__version__ = '0.0.1.dev1'

--- a/coalaip/__init__.py
+++ b/coalaip/__init__.py
@@ -4,7 +4,7 @@ __version__ = '0.0.1.dev1'
 
 from coalaip.coalaip import (  # noqa
     bind_plugin,
-    create_user,
+    generate_user,
     register_manifestation,
     derive_right,
     transfer_right

--- a/coalaip/coalaip.py
+++ b/coalaip/coalaip.py
@@ -126,11 +126,11 @@ class CoalaIp:
                              'created'))
         work_id = work.persist_id
 
-        manifestation_data['manifestationOf'] = work_id
+        manifestation_data['manifestationOfWork'] = work_id
         manifestation = Manifestation(manifestation_data, plugin=self._plugin)
         manifestation.create(user, **create_kwargs)
 
-        copyright_data = {'rightsOf': manifestation.id}
+        copyright_data = {'rightsOf': manifestation.persist_id}
         manifestation_copyright = Copyright(copyright_data, plugin=self._plugin)
         manifestation_copyright.create(user, **create_kwargs)
 

--- a/coalaip/coalaip.py
+++ b/coalaip/coalaip.py
@@ -52,7 +52,7 @@ class CoalaIp:
 
         return self._plugin.generate_user(*args, **kwargs)
 
-    # FIXME: could probably have a 'safe' check to make sure the entities are actually created
+    # TODO: could probably have a 'safe' check to make sure the entities are actually created
     def register_manifestation(self, manifestation_data, *, user,
                                existing_work=None, work_data=None,
                                data_format=None):

--- a/coalaip/coalaip.py
+++ b/coalaip/coalaip.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from coalaip.models import Copyright, Manifestation, Work
+from coalaip.plugin import AbstractPlugin
 
 
 RegistrationResult = namedtuple('RegistrationResult',
@@ -25,9 +26,12 @@ class CoalaIp:
             plugin (Plugin, keyword): the persistence layer plugin
         """
 
-        # FIXME: check that plugin is instance of AbstractPlugin
-        if not plugin:
-            raise ValueError('Provide a Plugin object')
+        if not isinstance(plugin, AbstractPlugin):
+            raise TypeError(('A plugin subclassing '
+                             "'coalaip.plugin.AbstractPlugin' must be "
+                             'provided when instantiating a CoalaIp instance. '
+                             'Given a plugin of type '
+                             "'{}' instead.".format(type(plugin))))
         self._plugin = plugin
 
     def __repr__(self):

--- a/coalaip/coalaip.py
+++ b/coalaip/coalaip.py
@@ -43,18 +43,20 @@ def bind_plugin(plugin):
     return BoundCoalaIp(plugin)
 
 
-def create_user(*, plugin, **kwargs):
-    """Create a new user for the backing persistence layer
+def create_user(*args, plugin, **kwargs):
+    """Create a new user for the backing persistence layer.
 
     Args:
-        plugin (): the persistence layer plugin
+        plugin (Plugin, keyword): the persistence layer plugin
+        *args: argument list passed to the plugin's create_user()
+        **kwargs: keyword arguments passed to the plugin's create_user()
 
     Returns:
         a representation of a user, based on the persistence layer
             plugin
     """
 
-    return plugin.create_user()
+    return plugin.create_user(*args, **kwargs)
 
 
 def register_manifestation(manifestation_data, *, user, existing_work=None,

--- a/coalaip/coalaip.py
+++ b/coalaip/coalaip.py
@@ -94,6 +94,12 @@ class CoalaIp:
                         'manifestation': (:class:`~coalaip.models.Manifestation`),
                         'work': (:class:`~coalaip.models.Work`),
                     )
+
+        Raises:
+            :class:`EntityCreationError`: if the manifestation, its
+                copyright, or the automatically created work (if no
+                existing work is given) fail to be created on the
+                persistence layer
         """
 
         # TODO: in the future, we may want to consider blocking (or asyncing) until

--- a/coalaip/coalaip.py
+++ b/coalaip/coalaip.py
@@ -1,0 +1,181 @@
+from collections import namedtuple
+from coalaip.models import Copyright, Manifestation, Work
+
+
+RegistrationResult = namedtuple('RegistrationResult',
+                                ['copyright', 'manifestation', 'work'])
+
+
+# FIXME: maybe there's a better way to accomplish this?
+class BoundCoalaIp:
+    """Plugin-bound CoalaIP top-level functions.
+
+    Instantiated with an subclass implementing the ledger plugin
+    interface (:class:`~coalaip.plugin.AbstractPlugin`) that will
+    automatically be bound to all top-level functions:
+        - :func:`create_user`
+        - :func:`register_manifestation`
+        - :func:`derive_right`
+        - :func:`transfer_right`
+    """
+
+    def __init__(self, plugin):
+        # FIXME: check that plugin is instance of AbstractPlugin
+        self._plugin = plugin
+
+    def create_user(self, *args, **kwargs):
+        create_user(plugin=self._plugin, *args, **kwargs)
+
+    def register_manifestation(self, *args, **kwargs):
+        register_manifestation(plugin=self._plugin, *args, **kwargs)
+
+    def derive_right(self, *args, **kwargs):
+        derive_right(plugin=self._plugin, *args, **kwargs)
+
+    def transfer_right(self, *args, **kwargs):
+        transfer_right(plugin=self._plugin, *args, **kwargs)
+
+    def __repr__(self):
+        return 'CoalaIp bound to plugin: {}'.format(self._plugin)
+
+
+def bind_plugin(plugin):
+    return BoundCoalaIp(plugin)
+
+
+def create_user(*, plugin, **kwargs):
+    """Create a new user for the backing persistence layer
+
+    Args:
+        plugin (): the persistence layer plugin
+
+    Returns:
+        a representation of a user, based on the persistence layer
+            plugin
+    """
+
+    return plugin.create_user()
+
+
+def register_manifestation(manifestation_data, *, user, existing_work=None,
+                           work_data=None, data_format=None, plugin):
+    """Register a Manifestation and automatically assign its
+    corresponding Copyright to the given 'user'.
+
+    Unless specified (see 'existing_work'), also registers a new Work
+    for the Manifestation.
+
+    Args:
+        manifestation_data (dict): a dict holding the model data for the
+            Manifestation
+        user (*, keyword): a user based on the format specified by the
+            persistence layer
+        existing_work (str|:class:`~coalaip.models.Work`), keyword, optional):
+            the id of an already existing Work that the Manifestation is
+            derived from.
+            If specified, the 'work_data' parameter is ignored.
+        work_data (dict, keyword, optional): a dict holding the model
+            data for the Work that will automatically generated for the
+            Manifestation if no existing work is specified.
+            If not specified, the Work will be created using only the
+            name of the Manifestation.
+        data_format (str, keyword, optional): the data format of the
+            created entities; must be one of:
+                - 'jsonld' (default)
+                - 'json'
+                - 'ipld'
+        plugin (Plugin, keyword): the persistence layer plugin
+
+    Returns:
+        namedtuple: a namedtuple containing the Coypright of the
+            registered Manifestation, the registered Manifestation,
+            and the Work (either the automatically created Work or the
+            given 'existing_work')::
+
+                (
+                    'copyright': (:class:`~coalaip.models.Copyright`),
+                    'manifestation': (:class:`~coalaip.models.Manifestation`),
+                    'work': (:class:`~coalaip.models.Work`),
+                )
+    """
+
+    # TODO: in the future, we may want to consider blocking (or asyncing) until
+    # we confirm that an entity has actually been created
+
+    # FIXME: is there a better way to do this? i.e. undefined in javascript
+    create_kwargs = {}
+    if data_format is not None:
+        create_kwargs['data_format'] = data_format
+
+    work = existing_work
+    if work is None:
+        if work_data is None:
+            work_data = {'name': manifestation_data.get('name')}
+        work = Work(work_data, plugin=plugin)
+        work.create(user, **create_kwargs)
+    elif not isinstance(work, Work):
+        raise ValueError(("'existing_work' argument to "
+                          'register_manifestation() must be a Work. '
+                          "Given an instance of '{}'".format(type(work))))
+    elif work.persist_id is not None:
+        raise TypeError(("Work given as 'existing_work' argument to "
+                         'register_manifestation() must have already been '
+                         'created'))
+    work_id = work.persist_id
+
+    manifestation_data['manifestationOf'] = work_id
+    manifestation = Manifestation(manifestation_data, plugin=plugin)
+    manifestation.create(user, **create_kwargs)
+
+    copyright_data = {'rightsOf': manifestation.id}
+    copyright = Copyright(copyright_data, plugin=plugin)
+    copyright.create(user, **create_kwargs)
+
+    return RegistrationResult(copyright, manifestation, work)
+
+
+def derive_right(right_data, copyright, *, user, data_format=None, plugin):
+    """Derive a new Right from a Manifestation's Copyright.
+
+    Args:
+        right_data (dict): a dict holding the model data for the Right
+        copyright (str): the id of the Copyright that this Right should
+            be derived from
+        user (*, keyword): a user based on the format specified by the
+            persistence layer
+        data_format (str, keyword, optional): the data format of the
+            created Right; must be one of:
+                - 'jsonld' (default)
+                - 'json'
+                - 'ipld'
+        plugin (Plugin, keyword): the persistence layer plugin
+
+    Returns:
+    """
+
+    raise NotImplementedError('derive_right() has not been implemented yet')
+
+
+def transfer_right(right, rights_assignment_data, *, from_user, to_user,
+                   data_format=None, plugin):
+    """Transfer a Right to another user.
+
+    Args:
+        right (str): the id of the Right to transfer
+        rights_assignment_data (dict): a dict holding the model data for
+            the RightsAssignment
+        from_user (*, keyword): a user based on the format specified by
+            the persistence layer
+        to_user (*, keyword): a user based on the format specified by
+            the persistence layer
+        data_format (str, keyword, optional): the data format of the
+            saved RightsAssignment; must be one of:
+                - 'jsonld' (default)
+                - 'json'
+                - 'ipld'
+        plugin (Plugin, keyword): the persistence layer plugin
+
+    Returns:
+    """
+
+    raise NotImplementedError('transfer_right() has not been implemented yet')

--- a/coalaip/coalaip.py
+++ b/coalaip/coalaip.py
@@ -125,19 +125,20 @@ class CoalaIp:
         manifestation.create(user, **create_kwargs)
 
         copyright_data = {'rightsOf': manifestation.id}
-        copyright = Copyright(copyright_data, plugin=self._plugin)
-        copyright.create(user, **create_kwargs)
+        manifestation_copyright = Copyright(copyright_data, plugin=self._plugin)
+        manifestation_copyright.create(user, **create_kwargs)
 
-        return RegistrationResult(copyright, manifestation, work)
+        return RegistrationResult(manifestation_copyright, manifestation, work)
 
-    def derive_right(self, right_data, copyright, *, user, data_format=None):
+    def derive_right(self, right_data, from_copyright, *, user,
+                     data_format=None):
         """Derive a new Right from a Manifestation's Copyright.
 
         Args:
             right_data (dict): a dict holding the model data for the
                 Right
-            copyright (str): the id of the Copyright that this Right
-                should be derived from
+            from_copyright (str): the id of the Copyright that this
+                Right should be derived from
             user (*, keyword): a user based on the format specified by
                 the persistence layer
             data_format (str, keyword, optional): the data format of the

--- a/coalaip/coalaip.py
+++ b/coalaip/coalaip.py
@@ -13,7 +13,7 @@ class BoundCoalaIp:
     Instantiated with an subclass implementing the ledger plugin
     interface (:class:`~coalaip.plugin.AbstractPlugin`) that will
     automatically be bound to all top-level functions:
-        - :func:`create_user`
+        - :func:`generate_user`
         - :func:`register_manifestation`
         - :func:`derive_right`
         - :func:`transfer_right`
@@ -23,8 +23,8 @@ class BoundCoalaIp:
         # FIXME: check that plugin is instance of AbstractPlugin
         self._plugin = plugin
 
-    def create_user(self, *args, **kwargs):
-        create_user(plugin=self._plugin, *args, **kwargs)
+    def generate_user(self, *args, **kwargs):
+        generate_user(plugin=self._plugin, *args, **kwargs)
 
     def register_manifestation(self, *args, **kwargs):
         register_manifestation(plugin=self._plugin, *args, **kwargs)
@@ -43,22 +43,23 @@ def bind_plugin(plugin):
     return BoundCoalaIp(plugin)
 
 
-def create_user(*args, plugin, **kwargs):
-    """Create a new user for the backing persistence layer.
+def generate_user(*args, plugin, **kwargs):
+    """Generate a new user for the backing persistence layer.
 
     Args:
         plugin (Plugin, keyword): the persistence layer plugin
-        *args: argument list passed to the plugin's create_user()
-        **kwargs: keyword arguments passed to the plugin's create_user()
+        *args: argument list passed to the plugin's generate_user()
+        **kwargs: keyword arguments passed to the plugin's generate_user()
 
     Returns:
         a representation of a user, based on the persistence layer
             plugin
     """
 
-    return plugin.create_user(*args, **kwargs)
+    return plugin.generate_user(*args, **kwargs)
 
 
+# FIXME: could probably have a 'safe' check to make sure the entities are actually created
 def register_manifestation(manifestation_data, *, user, existing_work=None,
                            work_data=None, data_format=None, plugin):
     """Register a Manifestation and automatically assign its

--- a/coalaip/context_urls.py
+++ b/coalaip/context_urls.py
@@ -1,0 +1,2 @@
+COALAIP = '<coalaip placeholder>'  # TODO: Change once context is hosted
+SCHEMA = 'http://schema.org/'

--- a/coalaip/exceptions.py
+++ b/coalaip/exceptions.py
@@ -3,11 +3,30 @@
 
 
 class EntityError(Exception):
-    """Raised when there is an error with the entity"""
+    """Base class for all entity errors. Raised when there is an error
+    with an entity
+    """
+
+
+class EntityCreationError(EntityError):
+    """Raised if an error occured during the creation of an entity.
+    Should contain the original error that caused the failure as the
+    first argument, if available.
+    """
+
+    @property
+    def error(self):
+        return self.args[0]
 
 
 class EntityDataError(EntityError, ValueError):
     """Raised if there is an error with the entity model's data"""
+
+
+class EntityNotFoundError(EntityError):
+    """Raised if the entity could not be found on the backing persistence
+    layer
+    """
 
 
 class EntityNotYetPersistedError(EntityError):
@@ -15,3 +34,13 @@ class EntityNotYetPersistedError(EntityError):
     persistence layer is attempted on an entity that has not been
     persisted yet
     """
+
+
+class EntityPreviouslyCreatedError(EntityError):
+    """Raised when attempting to persist an already persisted entity.
+    Should contain the existing id of the entity as the first argument.
+    """
+
+    @property
+    def existing_id(self):
+        return self.args[0]

--- a/coalaip/exceptions.py
+++ b/coalaip/exceptions.py
@@ -1,0 +1,17 @@
+"""Custom exceptions for COALA IP.
+"""
+
+
+class EntityError(Exception):
+    """Raised when there is an error with the entity"""
+
+
+class EntityDataError(EntityError, ValueError):
+    """Raised if there is an error with the entity model's data"""
+
+
+class EntityNotYetPersistedError(EntityError):
+    """Raised when an action requiring an entity to be available on the
+    persistence layer is attempted on an entity that has not been
+    persisted yet
+    """

--- a/coalaip/jsonld.py
+++ b/coalaip/jsonld.py
@@ -1,0 +1,22 @@
+import pyld
+
+
+jsonld = pyld.jsonld
+
+# Use a custom document loader to cache context requests
+# TODO: save coalaip and schema.org's context as .json files and load
+#       them here to avoid requesting them
+_default_document_loader = jsonld.get_document_loader()
+_CONTEXTS = {}
+
+
+def _custom_document_loader(url):
+    if url in _CONTEXTS:
+        return _CONTEXTS[url]
+
+    requested_ctx = _default_document_loader(url)
+    _CONTEXTS[url] = requested_ctx
+    return requested_ctx
+
+
+jsonld.set_document_loader(_custom_document_loader)

--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -12,6 +12,7 @@ from coalaip.exceptions import (
     EntityDataError,
     EntityNotYetPersistedError
 )
+from coalaip.plugin import AbstractPlugin
 
 
 DEFAULT_LD_CONTEXT = [context_urls.COALAIP, context_urls.SCHEMA]
@@ -32,7 +33,12 @@ class CoalaIpEntity:
         INSTANTIATION NOTES
         """
 
-        # FIXME: check that plugin is instance of AbstractPlugin
+        if not isinstance(plugin, AbstractPlugin):
+            raise TypeError(('A plugin subclassing '
+                             "'coalaip.plugin.AbstractPlugin' must be "
+                             'provided when instantiating a CoalaIp entity '
+                             'instance. Given a plugin of type '
+                             "'{}' instead.".format(type(plugin))))
 
         if not isinstance(entity_type, str):
             raise EntityDataError(('The entity type must be provided as a '

--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -219,7 +219,7 @@ class Manifestation(Creation):
     INSTANTIATION NOTES
     """
 
-    def __init__(self, data, *, entity_type=None, plugin, **kwargs):
+    def __init__(self, data, *, entity_type='CreativeWork', plugin, **kwargs):
         """Initialize a :class:`~coalaip.models.Manifestation` instance
 
         INSTANTIATION NOTES

--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -92,6 +92,7 @@ class CoalaIpEntity:
             the status of the entity, as defined by the persistence layer
         """
 
+        # FIXME: catch errors
         return self._plugin.get_status(self._persist_id)
 
     def to_json(self):

--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -1,0 +1,354 @@
+"""Low level models mirroring COALA IP's entity model
+
+Supports transformations of the entity into JSON, JSON-LD, and IPLD data
+formats, as well as creation and transferring through persistence layer
+plugin.
+"""
+
+from copy import copy
+from coalaip import context_urls
+from coalaip.exceptions import (
+    EntityError,
+    EntityDataError,
+    EntityNotYetPersistedError
+)
+
+
+DEFAULT_LD_CONTEXT = [context_urls.COALAIP, context_urls.SCHEMA]
+
+
+class CoalaIpEntity:
+    """Base class of all COALA IP entity models.
+
+    Provides base functionality for all COALA IP entities, including
+    entity creation (:method:`~CoalaIpEntity.create`) and, if necessary,
+    retrival of their status (:method:`~CoalaIpEntity.get_status`), on
+    the backing persistence layer provided by the given ledger plugin.
+    """
+
+    def __init__(self, data, *, ctx=DEFAULT_LD_CONTEXT, entity_type, plugin):
+        """Initialize a :class:`~coalaip.models.CoalaIpEntity` instance.
+
+        INSTANTIATION NOTES
+        """
+
+        # FIXME: check that plugin is instance of AbstractPlugin
+
+        if not isinstance(entity_type, str):
+            raise EntityDataError(('The entity type must be provided as a '
+                                   'string to the entity. '
+                                   'Got {} instead.').format(entity_type))
+
+        # FIXME: should I check that data is a dict?
+
+        self._data = data
+        self._entity_type = entity_type
+        self._ld_context = ctx
+        self._persist_id = None
+        self._plugin = plugin
+
+    def __repr__(self):
+        return "{name}: {data}".format(name=self.__class__.__name__,
+                                       data=self._data)
+
+    @property
+    def persist_id(self):
+        """(str|None): the id of this entity on the persistent backing
+        layer, if saved to one. Otherwise, None.
+        """
+        return self._persist_id
+
+    @property
+    def plugin_type(self):
+        """(str): the type of the plugin used by this entity"""
+        return self._plugin.type
+
+    def create(self, user, data_format='jsonld'):
+        """Create (i.e. persist) this entity to the backing persistence
+        layer
+
+        Args:
+            user (any): a user based on the model specified by the
+                persistence layer
+            data_format (str): the data format of the created entity;
+                must be one of:
+                    - 'jsonld' (default)
+                    - 'json'
+                    - 'ipld'
+
+        Returns:
+        """
+
+        entity_data = self._to_format(data_format)
+        # FIXME: catch errors
+        self._persist_id = self._plugin.save(entity_data, user=user)
+        return self._persist_id
+
+    def get_status(self):
+        """Get the current status of this entity, including it's state
+        in the backing persistence layer
+
+        Returns:
+            the status of the entity, as defined by the persistence layer
+        """
+
+        return self._plugin.get_status(self._persist_id)
+
+    def to_json(self):
+        """Output this entity as a JSON-serializable dict.
+
+        Returns:
+            dict: a JSON-serializable dict representing this entity's
+                data
+        """
+
+        json_model = copy(self._data)
+        json_model['type'] = self._entity_type
+        return json_model
+
+    def to_jsonld(self):
+        """Output this entity as a JSON-LD-serializable dict.
+
+        Returns:
+            dict: a JSON-LD-serializable dict representing this entity's
+                data
+        """
+
+        ld_model = copy(self._data)
+        ld_model['@context'] = self._ld_context
+        ld_model['@type'] = self._entity_type
+        ld_model['@id'] = ''  # Specifying an empty @id resolves to the current document
+        return ld_model
+
+    def to_ipld(self):
+        """Output this entity's data as an IPLD string"""
+
+        raise NotImplementedError('to_ipld() has not been implemented yet')
+
+    def _to_format(self, data_format):
+        if data_format == 'jsonld':
+            return self.to_jsonld()
+        elif data_format == 'json':
+            return self.to_json()
+        elif data_format == 'ipld':
+            raise NotImplementedError(('Saving entities as IPLD has not been '
+                                       'implemented yet.'))
+        else:
+            raise ValueError(("'data_format' argument should be one of "
+                              "'json', 'jsonld', or 'ipld'. "
+                              "Given '{}'.").format(data_format))
+
+
+class CoalaIpTransferrableEntity(CoalaIpEntity):
+    """Base class for transferable COALA IP entity models.
+
+    Provides functionality for transferrable entities through
+    (:method:`~CoalaIpTransferrableEntity.transfer`)
+    """
+
+    def transfer(self, transfer_payload=None, *, from_user, to_user):
+        """Transfer this entity to another owner on the backing
+        persistence layer
+
+        Args:
+            transfer_payload (dict): a dict holding the transfer's payload
+            from_user (any): a user based on the model specified by the
+                persistence layer
+            to_user (any): a user based on the model specified by the
+                persistence layer
+
+        Returns:
+        """
+
+        if self._persist_id is None:
+            raise EntityNotYetPersistedError(('Entities cannot be transferred '
+                                              'until they have been persisted'))
+        else:
+            return self._plugin.transfer(self._persist_id, transfer_payload,
+                                         from_user=from_user, to_user=to_user)
+
+
+class Creation(CoalaIpEntity):
+    """
+
+    INSTANTIATION NOTES
+    """
+
+    def __init__(self, data, *, entity_type='CreativeWork', plugin, **kwargs):
+        """Initialize a :class:`~coalaip.models.Creation` instance
+
+        INSTANTIATION NOTES
+        """
+
+        creation_name = data.get('name')
+
+        if not isinstance(creation_name, str):
+            # Proper error type... is ValueError right? Or KeyError? Or both?
+            raise EntityDataError(("'name' must be given as a string in the "
+                                   "'data' of Creations (Works and Manifestations). "
+                                   "Given '{}' instead.".format(creation_name)))
+
+        super().__init__(data, entity_type=entity_type, plugin=plugin, **kwargs)
+
+
+class Work(Creation):
+    """
+
+    INSTANTIATION NOTES
+    """
+
+    def __init__(self, data, *, plugin, **kwargs):
+        """Initialize a :class:`~coalaip.models.Work` instance
+
+        INSTANTIATION NOTES
+        """
+
+        if 'manifestationOfWork' in data:
+            raise EntityDataError(("'manifestationOfWork' must not be given "
+                                   "in the 'data' of Works"))
+        if data.get('isManifestation', False):
+            raise EntityDataError(("'isManifestation' must not be True if "
+                                   "given in the 'data' of Works"))
+
+        super().__init__(data, plugin=plugin, **kwargs)
+
+
+class Manifestation(Creation):
+    """
+
+    INSTANTIATION NOTES
+    """
+
+    def __init__(self, data, *, entity_type=None, plugin, **kwargs):
+        """Initialize a :class:`~coalaip.models.Manifestation` instance
+
+        INSTANTIATION NOTES
+        """
+
+        manifestation_of = data.get('manifestationOfWork')
+
+        if not isinstance(manifestation_of, str):
+            raise EntityDataError(("'manifestationOfWork' must be given as a "
+                                   "string in the 'data' of Copyrights. "
+                                   "Given '{}' instead.".format(manifestation_of)))
+
+        # If the entity type is already specified as part of the data, use that
+        # instead of 'CreativeWork'
+        for type_key in ['type', '@type']:
+            if type_key in data:
+                entity_type = data[type_key]
+                del data[type_key]
+                break
+
+        # FIXME: apply defaults
+        data['isManifestation'] = True
+        super().__init__(data, entity_type=entity_type, plugin=plugin, **kwargs)
+
+
+class Right(CoalaIpTransferrableEntity):
+    """
+
+    INSTANTIATION NOTES
+    """
+
+    def __init__(self, data, *, entity_type='Right', ctx=context_urls.COALAIP,
+                 plugin, **kwargs):
+        """Initialize a :class:`~coalaip.models.Right` instance
+
+        INSTANTIATION NOTES
+        """
+
+        # FIXME: apply defaults
+        super().__init__(data, ctx=ctx, entity_type=entity_type, plugin=plugin,
+                         **kwargs)
+
+    def transfer(self, rights_assignment_data=None, *, from_user, to_user,
+                 rights_assignment_format='jsonld'):
+        """Transfer this Right to another owner on the backing
+        persistence layer
+
+        Args:
+            rights_assignment_data (dict): a dict holding the model data for
+                the RightsAssignment
+            from_user (any): a user based on the model specified by the
+                persistence layer
+            to_user (any): a user based on the model specified by the
+                persistence layer
+            rights_assignment_format (str): the data format of the
+                created entity; must be one of:
+                    - 'jsonld' (default)
+                    - 'json'
+                    - 'ipld'
+
+        Returns:
+        """
+
+        transfer_payload = None
+        if rights_assignment_data is not None:
+            rights_assignment = RightsAssignment(rights_assignment_data,
+                                                 plugin=self._plugin)
+            transfer_payload = rights_assignment._to_format(
+                rights_assignment_format)
+
+        super().transfer(self._persist_id, transfer_payload,
+                         from_user=from_user, to_user=to_user)
+
+
+class Copyright(Right):
+    """
+
+    INSTANTIATION NOTES
+    """
+
+    def __init__(self, data, *, entity_type='Copyright', plugin, **kwargs):
+        """Initialize a :class:`~coalaip.models.Copyright` instance
+
+        INSTANTIATION NOTES
+        """
+
+        rights_of = data.get('rightsOf')
+
+        if not isinstance(rights_of, str):
+            raise EntityDataError(("'rightsOf' must be given as a string in "
+                                   "the 'data' of Copyrights. "
+                                   "Given '{}' instead.".format(rights_of)))
+
+        super().__init__(data, entity_type=entity_type, plugin=plugin, **kwargs)
+
+
+class GenericDerivedRight(Right):
+    """
+
+    INSTANTIATION NOTES
+    """
+
+    def __init__(self, data, *, entity_type='GenericDerivedRight', plugin,
+                 **kwargs):
+        """Initialize a :class:`~coalaip.models.GenericDerivedRight`
+        instance
+
+        INSTANTIATION NOTES
+        """
+
+        super().__init__(data, entity_type=entity_type, plugin=plugin, **kwargs)
+
+
+class RightsAssignment(CoalaIpEntity):
+    """
+
+    INSTANTIATION NOTES
+    """
+
+    def __init__(self, data, *, entity_type='RightsTransferAction', plugin,
+                 **kwargs):
+        """Initialize a :class:`~coalaip.models.RightsAssignment`
+        instance
+
+        INSTANTIATION NOTES
+        """
+
+        super().__init__(data, entity_type=entity_type, plugin=plugin, **kwargs)
+
+    def create(self):
+        raise EntityError(('RightsAssignments can only created through '
+                           'transer transactions.'))

--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -92,12 +92,15 @@ class CoalaIpEntity:
 
     def get_status(self):
         """Get the current status of this entity, including it's state
-        in the backing persistence layer
+        in the backing persistence layer.
 
         Returns:
-            the status of the entity, as defined by the persistence layer
+            the status of the entity, as defined by the persistence
+                layer, or None if the entity is not yet persisted.
         """
 
+        if self._persist_id is None:
+            return None
         # FIXME: catch errors
         return self._plugin.get_status(self._persist_id)
 

--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -359,6 +359,6 @@ class RightsAssignment(CoalaIpEntity):
 
         super().__init__(data, entity_type=entity_type, plugin=plugin, **kwargs)
 
-    def create(self):
+    def create(self, *args, **kwargs):
         raise EntityError(('RightsAssignments can only created through '
                            'transer transactions.'))

--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -300,8 +300,8 @@ class Right(CoalaIpTransferrableEntity):
             transfer_payload = rights_assignment._to_format(
                 rights_assignment_format)
 
-        super().transfer(self._persist_id, transfer_payload,
-                         from_user=from_user, to_user=to_user)
+        return super().transfer(transfer_payload, from_user=from_user,
+                                to_user=to_user)
 
 
 class Copyright(Right):

--- a/coalaip/plugin.py
+++ b/coalaip/plugin.py
@@ -1,0 +1,89 @@
+from abc import ABC, abstractmethod, abstractproperty
+
+
+class AbstractPlugin(ABC):
+    """Abstract interface for all persistence layer plugins.
+
+    Expects the following to be defined:
+        - :attr:`type`
+        - :func:`generate_user`
+        - :func:`get_status`
+        - :func:`save`
+        - :func:`transfer`
+    """
+
+    @abstractproperty
+    def type():
+        """A string denoting the type of plugin (e.g. BigchainDB)"""
+        return
+
+    @abstractmethod
+    def generate_user(self, *args, **kwargs):
+        """Generate a new user on the persistence layer.
+
+        Args:
+            *args: argument list, as necessary
+            **kwargs: keyword arguments, as necessary
+
+        Returns:
+            a representation of a user (e.g. a tuple with the user's
+                public and private keypair) on the persistence layer
+        """
+        return
+
+    @abstractmethod
+    def get_status(self, persist_id):
+        """Get the status of an entity on the persistence layer.
+
+        Args:
+            persist_id (str): the id of the entity on the persistence
+                layer
+
+        Returns:
+            the status of the entity, in any format.
+
+        Raises:
+            :class:`coalaip.exceptions.EntityNotFoundError`: if the
+                entity could not be found on the persistence layer
+        """
+        return
+
+    @abstractmethod
+    def save(self, entity_data, *, user):
+        """Create the entity on the persistence layer.
+
+        Args:
+            entity_data (dict): a dict holding the entity's data
+            user (, keyword): the user the entity should be assigned to
+                after creation. The user should be represented in the
+                same format as :meth:`generate_user`'s output.
+
+        Returns:
+            (str): the id of the created entity on the persistence layer
+
+        Raises:
+            :class:`coalaip.exceptions.EntityCreationError`: if the
+                entity failed to be created
+        """
+        return
+
+    @abstractmethod
+    def transfer(self, persist_id, transfer_payload, *, from_user, to_user):
+        """Transfer the entity whose id matches 'persist_id' on the
+        persistence layer from the current user to a new owner.
+
+        Args:
+            persist_id (str): the id of the entity on the persistence
+                layer
+            transfer_payload (dict): a dict holding the transfer's
+                payload
+            from_user (, keyword): the current owner, represented in the
+                same format as :meth:`generate_user`'s output
+            to_user (, keyword): the new owner, represented in the same
+                format as :meth:`generate_user`'s output
+
+        Returns:
+            (str): the id of the transfer action on the persistence
+                layer
+        """
+        return

--- a/coalaip/utils.py
+++ b/coalaip/utils.py
@@ -1,0 +1,6 @@
+# See http://stackoverflow.com/a/26853961/1375656
+def merge_two_dicts(x, y):
+    """Given two dicts, merge them into a new dict as a shallow copy."""
+    z = x.copy()
+    z.update(y)
+    return z

--- a/coalaip/utils.py
+++ b/coalaip/utils.py
@@ -1,6 +1,14 @@
 # See http://stackoverflow.com/a/26853961/1375656
-def merge_two_dicts(x, y):
-    """Given two dicts, merge them into a new dict as a shallow copy."""
+def extend_dict(x, *y):
+    """Similar to Object.assign() / _.extend() in Javascript, using
+    'dict.update()'
+
+    Args:
+        x (dict): the base dict to merge into with 'update()'
+        *y (dict, iter): any number of dictionary or iterable key/value
+            pairs to be sequentially merged into 'x'. Skipped if None.
+    """
     z = x.copy()
-    z.update(y)
+    for d in [d for d in y if d is not None]:
+        z.update(d)
     return z

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,8 @@
 Welcome to pycoalaip's documentation!
 ======================================
 
+.. important:: **Development Status: Pre-Alpha**
+
 Contents:
 
 .. toctree::

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,6 @@ watchdog==0.8.3
 flake8==2.6.0
 tox==2.3.1
 coverage==4.1
-pytest==2.9.2
+pytest==3.0.1
 pytest-cov
 Sphinx==1.4.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,6 @@ watchdog==0.8.3
 flake8==2.6.0
 tox==2.3.1
 coverage==4.1
-Sphinx==1.4.4
-
 pytest==2.9.2
+pytest-cov
+Sphinx==1.4.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,10 +1,5 @@
 pip==8.1.2
 bumpversion==0.5.3
 wheel==0.29.0
-watchdog==0.8.3
-flake8==2.6.0
-tox==2.3.1
-coverage==4.1
-pytest==3.0.1
-pytest-cov
-Sphinx==1.4.4
+
+-e .[dev]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,3 @@ replace = __version__ = '{new_version}'
 
 [wheel]
 universal = 0
-
-[flake8]
-exclude = docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.0.1.dev1
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
 [wheel]
-universal = 1
+universal = 0
 
 [flake8]
 exclude = docs

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,12 @@ install_requires = [
 ]
 
 tests_require = [
-    'coverage',
-    'pep8',
-    'pyflakes',
-    'pylint',
+    'tox>=2.3.1',
+    'coverage>=4.1',
+    'flake8>=2.6.0',
+    'pytest>=3.0.1',
     'pytest-cov',
+    'pytest-mock',
 ]
 
 dev_require = [
@@ -27,7 +28,7 @@ dev_require = [
 ]
 
 docs_require = [
-    'Sphinx>=1.3.5',
+    'Sphinx>=1.4.4',
     'sphinx-autobuild',
     'sphinxcontrib-napoleon>=0.4.4',
     'sphinx_rtd_theme',

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
+
+long_discription = readme + '\n\n' + history
 
 tests_require = [
     'coverage',
@@ -32,12 +34,11 @@ setup(
     name='coalaip',
     version='0.1.0',
     description="Python reference implementation for COALA IP",
-    long_description=readme + '\n\n' + history,
+    long_description=long_discription,
     author="BigchainDB",
     author_email='dev@bigchaindb.com',
     url='https://github.com/bigchaindb/pycoalaip',
-    packages=['coalaip'],
-    package_dir={'coalaip': 'coalaip'},
+    packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     install_requires=[],
     tests_require=tests_require,
@@ -46,6 +47,7 @@ setup(
         'dev': dev_require + tests_require + docs_require,
         'docs': docs_require,
     },
+    test_suite='tests',
     license="Apache Software License 2.0",
     keywords='coalaip',
     classifiers=[
@@ -57,5 +59,4 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    test_suite='tests',
 )

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ with open('HISTORY.rst') as history_file:
 long_discription = readme + '\n\n' + history
 
 install_requires = [
+    'PyLD'
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ with open('HISTORY.rst') as history_file:
 
 long_discription = readme + '\n\n' + history
 
+install_requires = [
+]
+
 tests_require = [
     'coverage',
     'pep8',
@@ -32,7 +35,7 @@ docs_require = [
 
 setup(
     name='coalaip',
-    version='0.1.0',
+    version='0.0.1.dev1',
     description="Python reference implementation for COALA IP",
     long_description=long_discription,
     author="BigchainDB",
@@ -40,7 +43,7 @@ setup(
     url='https://github.com/bigchaindb/pycoalaip',
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
-    install_requires=[],
+    install_requires=install_requires,
     tests_require=tests_require,
     extras_require={
         'test': tests_require,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,8 @@ def mock_plugin():
 
 @fixture
 def mock_bound_coalaip(mock_plugin):
-    from coalaip import bind_plugin
-    return bind_plugin(mock_plugin)
+    from coalaip import CoalaIp
+    return CoalaIp(mock_plugin)
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,212 @@
+from pytest import fixture
+
+from coalaip.context_urls import COALAIP
+from coalaip.models import DEFAULT_LD_CONTEXT
+from coalaip.utils import extend_dict
+
+from tests.utils import create_mock_plugin
+
+
+@fixture
+def alice_user():
+    return {'name': 'alice'}
+
+
+@fixture
+def bob_user():
+    return {'name': 'bob'}
+
+
+@fixture
+def mock_plugin():
+    return create_mock_plugin()
+
+
+@fixture
+def mock_bound_coalaip(mock_plugin):
+    from coalaip import bind_plugin
+    return bind_plugin(mock_plugin)
+
+
+@fixture
+def mock_model_status():
+    return 'valid'
+
+
+@fixture
+def work_data():
+    return {
+        'name': 'Title',
+    }
+
+
+@fixture
+def work_jsonld(work_data):
+    ld_data = {
+        '@context': DEFAULT_LD_CONTEXT,
+        '@type': 'CreativeWork',
+        '@id': '',
+    }
+    return extend_dict(ld_data, work_data)
+
+
+@fixture
+def work_json(work_data):
+    json_data = {
+        'type': 'CreativeWork',
+    }
+    return extend_dict(json_data, work_data)
+
+
+@fixture
+def work_model(mock_plugin, work_data):
+    from coalaip.models import Work
+    return Work(work_data, plugin=mock_plugin)
+
+
+@fixture
+def mock_work_create_id():
+    return 'mock_create_id'
+
+
+# FIXME: the factories should default their required IDs to the mock ones
+@fixture
+def manifestation_data_factory():
+    def factory(*, manifestationOfWork, data=None):
+        manifestation_data = {
+            'name': 'Title',
+            'creator': 'https://ipdb.foundation/api/transactions/12346789',
+            'manifestationOfWork': manifestationOfWork
+        }
+        return extend_dict(manifestation_data, data)
+
+    return factory
+
+
+@fixture
+def manifestation_jsonld_factory(manifestation_data_factory):
+    def factory(**kwargs):
+        ld_data = {
+            '@context': DEFAULT_LD_CONTEXT,
+            '@type': 'CreativeWork',
+            '@id': '',
+            'isManifestation': True,
+        }
+        return extend_dict(
+            ld_data,
+            manifestation_data_factory(**kwargs))
+
+    return factory
+
+
+@fixture
+def manifestation_json_factory(manifestation_data_factory):
+    def factory(**kwargs):
+        json_data = {
+            'type': 'CreativeWork',
+            'isManifestation': True,
+        }
+        return extend_dict(
+            json_data,
+            manifestation_data_factory(**kwargs))
+
+    return factory
+
+
+@fixture
+def manifestation_model(mock_plugin, manifestation_data_factory,
+                        mock_work_create_id):
+    from coalaip.models import Manifestation
+    manifestation_data = manifestation_data_factory(
+        manifestationOfWork=mock_work_create_id)
+    return Manifestation(manifestation_data, plugin=mock_plugin)
+
+
+@fixture
+def mock_manifestation_create_id():
+    return 'mock_manifestation_create_id'
+
+
+@fixture
+def copyright_data_factory():
+    def factory(*, rightsOf, data=None):
+        copyright_data = {
+            'rightsOf': rightsOf
+        }
+        return extend_dict(copyright_data, data)
+    return factory
+
+
+@fixture
+def copyright_jsonld_factory(copyright_data_factory):
+    def factory(**kwargs):
+        ld_data = {
+            '@context': COALAIP,
+            '@type': 'Copyright',
+            '@id': '',
+        }
+        return extend_dict(ld_data, copyright_data_factory(**kwargs))
+    return factory
+
+
+@fixture
+def copyright_json_factory(copyright_data_factory):
+    def factory(**kwargs):
+        json_data = {
+            'type': 'Copyright',
+        }
+        return extend_dict(json_data, copyright_data_factory(**kwargs))
+    return factory
+
+
+@fixture
+def copyright_model(mock_plugin, copyright_data_factory,
+                    mock_manifestation_create_id):
+    from coalaip.models import Copyright
+    copyright_data = copyright_data_factory(
+        rightsOf=mock_manifestation_create_id)
+    return Copyright(copyright_data, plugin=mock_plugin)
+
+
+@fixture
+def transfer_contract_url():
+    return 'https://ipdb.s3.amazonaws.com/1234567890.pdf'
+
+
+@fixture
+def rights_assignment_jsonld(transfer_contract_url):
+    return {
+        '@context': DEFAULT_LD_CONTEXT,
+        '@type': 'RightsTransferAction',
+        'transferContract': transfer_contract_url
+    }
+
+
+@fixture
+def rights_assignment_json(transfer_contract_url):
+    return {
+        'type': 'RightsTransferAction',
+        'transferContract': transfer_contract_url
+    }
+
+
+@fixture
+def rights_assignment_model(mock_plugin, rights_assignment_json):
+    from coalaip.models import RightsAssignment
+    return RightsAssignment(rights_assignment_json, plugin=mock_plugin)
+
+
+@fixture
+def persisted_registration(mock_bound_coalaip, manifestation_data_factory,
+                           alice_user):
+    # Create the default manifestation model, but remove the
+    # 'manifestationOfWork' key since it'll be created through registration
+    manifestation_model = manifestation_data_factory(
+        manifestationOfWork='none'
+    )
+    del manifestation_model['manifestationOfWork']
+
+    return mock_bound_coalaip.register_manifestation(
+        manifestation_model,
+        user=alice_user
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,6 @@ from coalaip.context_urls import COALAIP
 from coalaip.models import DEFAULT_LD_CONTEXT
 from coalaip.utils import extend_dict
 
-from tests.utils import create_mock_plugin
-
 
 @fixture
 def alice_user():
@@ -19,11 +17,12 @@ def bob_user():
 
 @fixture
 def mock_plugin():
+    from tests.utils import create_mock_plugin
     return create_mock_plugin()
 
 
 @fixture
-def mock_bound_coalaip(mock_plugin):
+def mock_coalaip(mock_plugin):
     from coalaip import CoalaIp
     return CoalaIp(mock_plugin)
 
@@ -230,16 +229,25 @@ def mock_rights_assignment_create_id():
 
 
 @fixture
-def persisted_registration(mock_bound_coalaip, manifestation_data_factory,
-                           alice_user):
+def persisted_jsonld_registration(mock_plugin, mock_coalaip,
+                                  manifestation_data_factory, alice_user,
+                                  mock_work_create_id,
+                                  mock_manifestation_create_id,
+                                  mock_copyright_create_id):
+    from tests.utils import create_entity_id_setter
+
     # Create the default manifestation model, but remove the
     # 'manifestationOfWork' key since it'll be created through registration
-    manifestation_model = manifestation_data_factory(
-        manifestationOfWork='none'
-    )
+    manifestation_model = manifestation_data_factory()
     del manifestation_model['manifestationOfWork']
 
-    return mock_bound_coalaip.register_manifestation(
+    # Set the persisted ids of the entities
+    mock_plugin.save.side_effect = create_entity_id_setter(
+        mock_work_create_id,
+        mock_manifestation_create_id,
+        mock_copyright_create_id)
+
+    return mock_coalaip.register_manifestation(
         manifestation_model,
         user=alice_user
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,10 +69,9 @@ def mock_work_create_id():
     return 'mock_create_id'
 
 
-# FIXME: the factories should default their required IDs to the mock ones
 @fixture
-def manifestation_data_factory():
-    def factory(*, manifestationOfWork, data=None):
+def manifestation_data_factory(mock_work_create_id):
+    def factory(*, manifestationOfWork=mock_work_create_id, data=None):
         manifestation_data = {
             'name': 'Title',
             'creator': 'https://ipdb.foundation/api/transactions/12346789',
@@ -128,8 +127,13 @@ def mock_manifestation_create_id():
 
 
 @fixture
-def copyright_data_factory():
-    def factory(*, rightsOf, data=None):
+def mock_manifestation_type():
+    return 'mock_manifestation_type'
+
+
+@fixture
+def copyright_data_factory(mock_manifestation_create_id):
+    def factory(*, rightsOf=mock_manifestation_create_id, data=None):
         copyright_data = {
             'rightsOf': rightsOf
         }
@@ -169,31 +173,49 @@ def copyright_model(mock_plugin, copyright_data_factory,
 
 
 @fixture
+def mock_copyright_create_id():
+    return 'mock_copyright_create_id'
+
+
+@fixture
 def transfer_contract_url():
     return 'https://ipdb.s3.amazonaws.com/1234567890.pdf'
 
 
 @fixture
-def rights_assignment_jsonld(transfer_contract_url):
+def rights_assignment_data(transfer_contract_url):
     return {
-        '@context': DEFAULT_LD_CONTEXT,
-        '@type': 'RightsTransferAction',
         'transferContract': transfer_contract_url
     }
 
 
 @fixture
-def rights_assignment_json(transfer_contract_url):
-    return {
-        'type': 'RightsTransferAction',
-        'transferContract': transfer_contract_url
+def rights_assignment_jsonld(rights_assignment_data):
+    ld_data = {
+        '@context': DEFAULT_LD_CONTEXT,
+        '@type': 'RightsTransferAction',
+        '@id': '',
     }
+    return extend_dict(ld_data, rights_assignment_data)
+
+
+@fixture
+def rights_assignment_json(rights_assignment_data):
+    json_data = {
+        'type': 'RightsTransferAction',
+    }
+    return extend_dict(json_data, rights_assignment_data)
 
 
 @fixture
 def rights_assignment_model(mock_plugin, rights_assignment_json):
     from coalaip.models import RightsAssignment
     return RightsAssignment(rights_assignment_json, plugin=mock_plugin)
+
+
+@fixture
+def mock_rights_assignment_create_id():
+    return 'mock_rights_assignment_create_id'
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,17 @@ def mock_model_status():
 
 
 @fixture
+def base_entity_model(mock_plugin):
+    from coalaip.models import CoalaIpEntity
+    return CoalaIpEntity(data={}, entity_type='type', plugin=mock_plugin)
+
+
+@fixture
+def mock_base_entity_create_id():
+    return 'mock_entity_create_id'
+
+
+@fixture
 def work_data():
     return {
         'name': 'Title',

--- a/tests/test_coalaip.py
+++ b/tests/test_coalaip.py
@@ -1,6 +1,101 @@
 #!/usr/bin/env python
 
-from pytest import mark
+from pytest import mark, raises
 
 
+def test_coalaip_expects_plugin():
+    from coalaip.coalaip import CoalaIp
 
+    with raises(TypeError):
+        CoalaIp()
+
+
+def test_generate_user(mock_plugin, mock_coalaip, alice_user):
+    mock_plugin.generate_user.return_value = alice_user
+    generate_user_args = ['arg1']
+    generate_user_kwargs = {'arg2': 'arg2'}
+
+    generated_user = mock_coalaip.generate_user(*generate_user_args,
+                                                **generate_user_kwargs)
+    assert alice_user == generated_user
+    mock_plugin.generate_user.assert_called_with(*generate_user_args,
+                                                 **generate_user_kwargs)
+
+
+@mark.parametrize('data_format', [(''), ('json'), ('jsonld')])
+@mark.parametrize('work_data', [None, {'name': 'mock_work_name'}])
+def test_register_manifestation(mock_plugin, mock_coalaip,
+                                manifestation_data_factory, alice_user,
+                                data_format, work_data, mock_work_create_id,
+                                mock_manifestation_create_id,
+                                mock_copyright_create_id):
+    from tests.utils import (
+        assert_key_values_present_in_dict,
+        create_entity_id_setter
+    )
+
+    # Create the default manifestation model, but remove the
+    # 'manifestationOfWork' key since it'll be created through registration
+    manifestation_model = manifestation_data_factory()
+    del manifestation_model['manifestationOfWork']
+
+    # Set the persisted ids of the entities
+    mock_plugin.save.side_effect = create_entity_id_setter(
+        mock_work_create_id,
+        mock_manifestation_create_id,
+        mock_copyright_create_id,
+        type_key='type' if data_format == 'json' else '@type')
+
+    register_manifestation_kwargs = {}
+    if data_format:
+        register_manifestation_kwargs['data_format'] = data_format
+
+    # Test the entities were persisted
+    manifestation_copyright, manifestation, work = mock_coalaip.register_manifestation(
+        manifestation_model,
+        user=alice_user,
+        work_data=work_data,
+        **register_manifestation_kwargs,
+    )
+    assert manifestation_copyright.persist_id == mock_copyright_create_id
+    assert manifestation.persist_id == mock_manifestation_create_id
+    assert work.persist_id == mock_work_create_id
+
+    # Test the correct data format was persisted
+    if data_format == 'json':
+        manifestation_persisted_data = manifestation.to_json()
+        copyright_persisted_data = manifestation_copyright.to_json()
+        work_persisted_data = work.to_json()
+    elif data_format == 'ipld':
+        raise NotImplementedError('IPLD is not implemented yet')
+    else:
+        manifestation_persisted_data = manifestation.to_jsonld()
+        copyright_persisted_data = manifestation_copyright.to_jsonld()
+        work_persisted_data = work.to_jsonld()
+
+    # If given custom Work information, make sure that is reflected in the
+    # entities
+    if work_data:
+        assert_key_values_present_in_dict(work_persisted_data, **work_data)
+
+    mock_save_call_list = mock_plugin.save.call_args_list
+    assert mock_save_call_list[0] == (
+        (work_persisted_data,),
+        {'user': alice_user}
+    )
+    assert mock_save_call_list[1] == (
+        (manifestation_persisted_data,),
+        {'user': alice_user}
+    )
+    assert mock_save_call_list[2] == (
+        (copyright_persisted_data,),
+        {'user': alice_user}
+    )
+
+
+def test_register_manifestation_with_existing_work():
+    pass
+
+
+def test_register_manifestation_raises_on_creation_error():
+    pass

--- a/tests/test_coalaip.py
+++ b/tests/test_coalaip.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 test_coalaip
@@ -26,4 +25,3 @@ class TestCoalaip(object):
     @classmethod
     def teardown_class(cls):
         pass
-

--- a/tests/test_coalaip.py
+++ b/tests/test_coalaip.py
@@ -1,27 +1,6 @@
 #!/usr/bin/env python
 
-"""
-test_coalaip
-----------------------------------
-
-Tests for `coalaip` module.
-"""
-
-import pytest
+from pytest import mark
 
 
-from coalaip import coalaip
 
-
-class TestCoalaip(object):
-
-    @classmethod
-    def setup_class(cls):
-        pass
-
-    def test_something(self):
-        pass
-
-    @classmethod
-    def teardown_class(cls):
-        pass

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,21 @@
 from pytest import mark, raises
 
 
+def test_entities_raise_on_bad_plugin():
+    from coalaip.models import CoalaIpEntity
+
+    with raises(TypeError):
+        CoalaIpEntity(data={}, plugin=None)
+
+    # Test that plugins also need to be subclassed from AbstractPlugin
+    class NonSubclassPlugin():
+        pass
+
+    plugin = NonSubclassPlugin()
+    with raises(TypeError):
+        CoalaIpEntity(data={}, plugin=plugin)
+
+
 def test_work_init(mock_plugin, work_data, work_json,
                    work_jsonld):
     from coalaip.models import Work
@@ -12,7 +27,6 @@ def test_work_init(mock_plugin, work_data, work_json,
     assert work.to_jsonld() == work_jsonld
 
 
-# TODO: Add ipld
 @mark.parametrize('data_format,model_data_name', [
     ('', 'work_jsonld'),
     ('json', 'work_json'),
@@ -39,9 +53,18 @@ def test_work_create_raises_on_bad_format(work_model, alice_user):
         work_model.create(alice_user, 'bad_format')
 
 
-def test_work_get_status(mock_plugin, work_model, mock_model_status):
+def test_work_get_status_none_if_not_persisted(mock_plugin, work_model):
+    status = work_model.get_status()
+    assert mock_plugin.get_status.call_count == 0
+    assert status is None
+
+
+def test_work_get_status(mock_plugin, work_model, mock_work_create_id,
+                         mock_model_status):
     mock_plugin.get_status.return_value = mock_model_status
 
+    # Fake that the work's been persisted and try again
+    work_model._persist_id = mock_work_create_id
     status = work_model.get_status()
     assert mock_plugin.get_status.call_count == 1
     assert status == mock_model_status
@@ -52,18 +75,37 @@ def test_work_non_transferrable(work_model):
         work_model.transfer()
 
 
-def test_manifestation_init(mock_plugin, mock_work_create_id,
-                            manifestation_data_factory,
+def test_manifestation_init(mock_plugin, manifestation_data_factory,
                             manifestation_json_factory,
                             manifestation_jsonld_factory):
     from coalaip.models import Manifestation
 
-    manifestation_data = manifestation_data_factory(
-        manifestationOfWork=mock_work_create_id)
-    manifestation_json = manifestation_json_factory(
-        manifestationOfWork=mock_work_create_id)
-    manifestation_jsonld = manifestation_jsonld_factory(
-        manifestationOfWork=mock_work_create_id)
+    manifestation_data = manifestation_data_factory()
+    manifestation_json = manifestation_json_factory()
+    manifestation_jsonld = manifestation_jsonld_factory()
+
+    manifestation = Manifestation(manifestation_data, plugin=mock_plugin)
+    assert manifestation.persist_id is None
+    assert manifestation.to_json() == manifestation_json
+    assert manifestation.to_jsonld() == manifestation_jsonld
+
+
+@mark.parametrize('type_key', ['type', '@type'])
+def test_manifestation_init_with_type(mock_plugin, manifestation_data_factory,
+                                      manifestation_json_factory,
+                                      manifestation_jsonld_factory, type_key,
+                                      mock_manifestation_type):
+    from coalaip.models import Manifestation
+
+    manifestation_data = manifestation_data_factory(data={
+        type_key: mock_manifestation_type
+    })
+    manifestation_json = manifestation_json_factory(data={
+        'type': mock_manifestation_type
+    })
+    manifestation_jsonld = manifestation_jsonld_factory(data={
+        '@type': mock_manifestation_type
+    })
 
     manifestation = Manifestation(manifestation_data, plugin=mock_plugin)
     assert manifestation.persist_id is None
@@ -76,8 +118,7 @@ def test_manifestation_init_raise_without_manifestation_of(
     from coalaip.models import Manifestation
     from coalaip.exceptions import EntityDataError
 
-    manifestation_data = manifestation_data_factory(
-        manifestationOfWork='')
+    manifestation_data = manifestation_data_factory()
     del manifestation_data['manifestationOfWork']
 
     with raises(EntityDataError):
@@ -91,7 +132,6 @@ def test_manifestation_init_raise_without_manifestation_of(
 ])
 def test_manifestation_create(mock_plugin, manifestation_model, alice_user,
                               data_format, model_factory_name,
-                              mock_work_create_id,
                               mock_manifestation_create_id, request):
     mock_plugin.save.return_value = mock_manifestation_create_id
 
@@ -104,15 +144,25 @@ def test_manifestation_create(mock_plugin, manifestation_model, alice_user,
     assert persist_id == manifestation_model.persist_id
 
     model_factory = request.getfixturevalue(model_factory_name)
-    model_data = model_factory(manifestationOfWork=mock_work_create_id)
+    model_data = model_factory()
 
     mock_plugin.save.assert_called_with(model_data, user=alice_user)
 
 
+def test_manifestation_get_status_none_if_not_persisted(mock_plugin,
+                                                        manifestation_model):
+    status = manifestation_model.get_status()
+    assert mock_plugin.get_status.call_count == 0
+    assert status is None
+
+
 def test_manifestation_get_status(mock_plugin, manifestation_model,
+                                  mock_manifestation_create_id,
                                   mock_model_status):
     mock_plugin.get_status.return_value = mock_model_status
 
+    # Fake that the copyright's been persisted and try to transfer again
+    manifestation_model._persist_id = mock_manifestation_create_id
     status = manifestation_model.get_status()
     assert mock_plugin.get_status.call_count == 1
     assert status == mock_model_status
@@ -123,37 +173,130 @@ def test_manifestation_non_transferrable(manifestation_model):
         manifestation_model.transfer()
 
 
-def test_copyright_init(mock_plugin, copyright_data_factory):
+def test_copyright_init(mock_plugin, copyright_data_factory,
+                        copyright_json_factory, copyright_jsonld_factory):
     from coalaip.models import Copyright
 
+    copyright_data = copyright_data_factory()
+    copyright_json = copyright_json_factory()
+    copyright_jsonld = copyright_jsonld_factory()
 
-def test_copyright_init_raise_without_rights_of():
-    pass
-
-
-def test_copyright_create(copyright_model, mock_manifestation_create_id,
-                          copyright_data_factory):
-    pass
-
-
-def test_copyright_get_status(copyright_model):
-    pass
+    copyright = Copyright(copyright_data, plugin=mock_plugin)
+    assert copyright.persist_id is None
+    assert copyright.to_json() == copyright_json
+    assert copyright.to_jsonld() == copyright_jsonld
 
 
-def test_copyright_transferrable():
-    pass
+def test_copyright_init_raise_without_rights_of(mock_plugin,
+                                                copyright_data_factory):
+    from coalaip.models import Copyright
+    from coalaip.exceptions import EntityDataError
+
+    copyright_data = copyright_data_factory(rightsOf='')
+    del copyright_data['rightsOf']
+
+    with raises(EntityDataError):
+        Copyright(copyright_data, plugin=mock_plugin)
 
 
-def test_rights_assignment_init(mock_plugin):
+@mark.parametrize('data_format,model_factory_name', [
+    ('', 'copyright_jsonld_factory'),
+    ('json', 'copyright_json_factory'),
+    ('jsonld', 'copyright_jsonld_factory'),
+])
+def test_copyright_create(mock_plugin, copyright_model, alice_user,
+                          data_format, model_factory_name,
+                          mock_copyright_create_id, request):
+    mock_plugin.save.return_value = mock_copyright_create_id
+
+    if data_format:
+        persist_id = copyright_model.create(alice_user, data_format)
+    else:
+        persist_id = copyright_model.create(alice_user)
+    assert mock_plugin.save.call_count == 1
+    assert persist_id == mock_copyright_create_id
+    assert persist_id == copyright_model.persist_id
+
+    model_factory = request.getfixturevalue(model_factory_name)
+    model_data = model_factory()
+
+    mock_plugin.save.assert_called_with(model_data, user=alice_user)
+
+
+def test_copyright_get_status_none_if_not_persisted(mock_plugin,
+                                                    copyright_model):
+    status = copyright_model.get_status()
+    assert mock_plugin.get_status.call_count == 0
+    assert status is None
+
+
+def test_copyright_get_status(mock_plugin, copyright_model,
+                              mock_copyright_create_id, mock_model_status):
+    mock_plugin.get_status.return_value = mock_model_status
+
+    # Fake that the copyright's been persisted and try to transfer again
+    copyright_model._persist_id = mock_copyright_create_id
+    status = copyright_model.get_status()
+    assert mock_plugin.get_status.call_count == 1
+    assert status == mock_model_status
+
+
+@mark.parametrize('data_format,rights_assignment_data_name', [
+    ('', 'rights_assignment_jsonld'),
+    ('json', 'rights_assignment_json'),
+    ('jsonld', 'rights_assignment_jsonld'),
+])
+def test_copyright_transferrable(mock_plugin, copyright_model,
+                                 rights_assignment_data, alice_user, bob_user,
+                                 data_format, rights_assignment_data_name,
+                                 mock_copyright_create_id,
+                                 mock_rights_assignment_create_id, request):
+    from coalaip.exceptions import EntityNotYetPersistedError
+
+    mock_plugin.transfer.return_value = mock_rights_assignment_create_id
+
+    with raises(EntityNotYetPersistedError):
+        copyright_model.transfer(rights_assignment_data, from_user=alice_user,
+                                 to_user=bob_user)
+
+    # Fake that the copyright's been persisted and try to transfer again
+    copyright_model._persist_id = mock_copyright_create_id
+
+    transfer_kwargs = {
+        'from_user': alice_user,
+        'to_user': bob_user
+    }
+    if data_format:
+        transfer_kwargs['rights_assignment_format'] = data_format
+
+    transfer_tx_id = copyright_model.transfer(rights_assignment_data,
+                                              **transfer_kwargs)
+    assert transfer_tx_id == mock_rights_assignment_create_id
+
+    rights_assignment_model_data = request.getfixturevalue(
+        rights_assignment_data_name)
+    mock_plugin.transfer.assert_called_with(mock_copyright_create_id,
+                                            rights_assignment_model_data,
+                                            from_user=alice_user,
+                                            to_user=bob_user)
+
+
+def test_rights_assignment_init(mock_plugin, rights_assignment_data,
+                                rights_assignment_json,
+                                rights_assignment_jsonld):
     from coalaip.models import RightsAssignment
 
+    rights_assignment = RightsAssignment(rights_assignment_data,
+                                         plugin=mock_plugin)
+    assert rights_assignment.persist_id is None
+    assert rights_assignment.to_json() == rights_assignment_json
+    assert rights_assignment.to_jsonld() == rights_assignment_jsonld
 
-def test_rights_assignment_init_raise_without_plugin():
-    pass
 
-
-def test_rights_assignment_cannot_create(rights_assignment_model):
-    pass
+def test_rights_assignment_cannot_create(rights_assignment_model, alice_user):
+    from coalaip.exceptions import EntityError
+    with raises(EntityError):
+        rights_assignment_model.create(user=alice_user)
 
 
 @mark.skip('Rights Assignments require transfer() to be implemented')
@@ -161,5 +304,6 @@ def test_rights_assignment_get_status(rights_assignment_model):
     pass
 
 
-def test_rights_assignment_non_transferrable():
-    pass
+def test_rights_assignment_non_transferrable(rights_assignment_model):
+    with raises(AttributeError):
+        rights_assignment_model.transfer()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+
+from pytest import mark, raises
+
+
+def test_work_init(mock_plugin, work_data, work_json,
+                   work_jsonld):
+    from coalaip.models import Work
+    work = Work(work_data, plugin=mock_plugin)
+    assert work.persist_id is None
+    assert work.to_json() == work_json
+    assert work.to_jsonld() == work_jsonld
+
+
+# TODO: Add ipld
+@mark.parametrize('data_format,model_data_name', [
+    ('', 'work_jsonld'),
+    ('json', 'work_json'),
+    ('jsonld', 'work_jsonld'),
+])
+def test_work_create(mock_plugin, work_model, alice_user, data_format,
+                     model_data_name, mock_work_create_id, request):
+    mock_plugin.save.return_value = mock_work_create_id
+
+    if data_format:
+        persist_id = work_model.create(alice_user, data_format)
+    else:
+        persist_id = work_model.create(alice_user)
+    assert mock_plugin.save.call_count == 1
+    assert persist_id == mock_work_create_id
+    assert persist_id == work_model.persist_id
+
+    model_data = request.getfixturevalue(model_data_name)
+    mock_plugin.save.assert_called_with(model_data, user=alice_user)
+
+
+def test_work_create_raises_on_bad_format(work_model, alice_user):
+    with raises(ValueError):
+        work_model.create(alice_user, 'bad_format')
+
+
+def test_work_get_status(mock_plugin, work_model, mock_model_status):
+    mock_plugin.get_status.return_value = mock_model_status
+
+    status = work_model.get_status()
+    assert mock_plugin.get_status.call_count == 1
+    assert status == mock_model_status
+
+
+def test_work_non_transferrable(work_model):
+    with raises(AttributeError):
+        work_model.transfer()
+
+
+def test_manifestation_init(mock_plugin, mock_work_create_id,
+                            manifestation_data_factory,
+                            manifestation_json_factory,
+                            manifestation_jsonld_factory):
+    from coalaip.models import Manifestation
+
+    manifestation_data = manifestation_data_factory(
+        manifestationOfWork=mock_work_create_id)
+    manifestation_json = manifestation_json_factory(
+        manifestationOfWork=mock_work_create_id)
+    manifestation_jsonld = manifestation_jsonld_factory(
+        manifestationOfWork=mock_work_create_id)
+
+    manifestation = Manifestation(manifestation_data, plugin=mock_plugin)
+    assert manifestation.persist_id is None
+    assert manifestation.to_json() == manifestation_json
+    assert manifestation.to_jsonld() == manifestation_jsonld
+
+
+def test_manifestation_init_raise_without_manifestation_of(
+        mock_plugin, manifestation_data_factory):
+    from coalaip.models import Manifestation
+    from coalaip.exceptions import EntityDataError
+
+    manifestation_data = manifestation_data_factory(
+        manifestationOfWork='')
+    del manifestation_data['manifestationOfWork']
+
+    with raises(EntityDataError):
+        Manifestation(manifestation_data, plugin=mock_plugin)
+
+
+@mark.parametrize('data_format,model_factory_name', [
+    ('', 'manifestation_jsonld_factory'),
+    ('json', 'manifestation_json_factory'),
+    ('jsonld', 'manifestation_jsonld_factory'),
+])
+def test_manifestation_create(mock_plugin, manifestation_model, alice_user,
+                              data_format, model_factory_name,
+                              mock_work_create_id,
+                              mock_manifestation_create_id, request):
+    mock_plugin.save.return_value = mock_manifestation_create_id
+
+    if data_format:
+        persist_id = manifestation_model.create(alice_user, data_format)
+    else:
+        persist_id = manifestation_model.create(alice_user)
+    assert mock_plugin.save.call_count == 1
+    assert persist_id == mock_manifestation_create_id
+    assert persist_id == manifestation_model.persist_id
+
+    model_factory = request.getfixturevalue(model_factory_name)
+    model_data = model_factory(manifestationOfWork=mock_work_create_id)
+
+    mock_plugin.save.assert_called_with(model_data, user=alice_user)
+
+
+def test_manifestation_get_status(mock_plugin, manifestation_model,
+                                  mock_model_status):
+    mock_plugin.get_status.return_value = mock_model_status
+
+    status = manifestation_model.get_status()
+    assert mock_plugin.get_status.call_count == 1
+    assert status == mock_model_status
+
+
+def test_manifestation_non_transferrable(manifestation_model):
+    with raises(AttributeError):
+        manifestation_model.transfer()
+
+
+def test_copyright_init(mock_plugin, copyright_data_factory):
+    from coalaip.models import Copyright
+
+
+def test_copyright_init_raise_without_rights_of():
+    pass
+
+
+def test_copyright_create(copyright_model, mock_manifestation_create_id,
+                          copyright_data_factory):
+    pass
+
+
+def test_copyright_get_status(copyright_model):
+    pass
+
+
+def test_copyright_transferrable():
+    pass
+
+
+def test_rights_assignment_init(mock_plugin):
+    from coalaip.models import RightsAssignment
+
+
+def test_rights_assignment_init_raise_without_plugin():
+    pass
+
+
+def test_rights_assignment_cannot_create(rights_assignment_model):
+    pass
+
+
+@mark.skip('Rights Assignments require transfer() to be implemented')
+def test_rights_assignment_get_status(rights_assignment_model):
+    pass
+
+
+def test_rights_assignment_non_transferrable():
+    pass

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,7 @@
 from pytest import mark, raises
 
 
-def test_entities_raise_on_bad_plugin():
+def test_entities_raises_on_bad_plugin():
     from coalaip.models import CoalaIpEntity
 
     with raises(TypeError):
@@ -18,8 +18,8 @@ def test_entities_raise_on_bad_plugin():
         CoalaIpEntity(data={}, entity_type='type', plugin=plugin)
 
 
-def test_entities_raise_on_creation_error(mock_plugin, base_entity_model,
-                                          alice_user):
+def test_entities_raises_on_creation_error(mock_plugin, base_entity_model,
+                                           alice_user):
     from coalaip.exceptions import EntityCreationError
 
     mock_creation_error = 'mock_creation_error'
@@ -30,7 +30,7 @@ def test_entities_raise_on_creation_error(mock_plugin, base_entity_model,
     assert mock_creation_error == excinfo.value.error
 
 
-def test_entities_raise_on_creation_if_already_created(
+def test_entities_raises_on_creation_if_already_created(
         mock_plugin, base_entity_model, alice_user,
         mock_base_entity_create_id):
     from coalaip.exceptions import EntityPreviouslyCreatedError
@@ -51,8 +51,8 @@ def test_entities_raise_on_creation_if_already_created(
 def test_entities_have_none_status_if_not_persisted(mock_plugin,
                                                     base_entity_model):
     status = base_entity_model.get_status()
-    assert mock_plugin.get_status.call_count == 0
     assert status is None
+    mock_plugin.get_status.assert_not_called()
 
 
 def test_entities_get_status(mock_plugin, base_entity_model, alice_user,
@@ -68,9 +68,9 @@ def test_entities_get_status(mock_plugin, base_entity_model, alice_user,
     assert status == mock_model_status
 
 
-def test_entities_raise_on_status_if_not_found(mock_plugin, base_entity_model,
-                                               alice_user,
-                                               mock_base_entity_create_id):
+def test_entities_raises_on_status_if_not_found(mock_plugin, base_entity_model,
+                                                alice_user,
+                                                mock_base_entity_create_id):
     from coalaip.exceptions import EntityNotFoundError
 
     # Save the entity
@@ -89,6 +89,22 @@ def test_work_init(mock_plugin, work_data, work_json,
     assert work.persist_id is None
     assert work.to_json() == work_json
     assert work.to_jsonld() == work_jsonld
+
+
+def test_work_init_raises_if_manifestation(mock_plugin, work_data):
+    from copy import copy
+    from coalaip.models import Work
+    from coalaip.exceptions import EntityDataError
+
+    is_manifestation_data = copy(work_data)
+    is_manifestation_data['isManifestation'] = True
+    with raises(EntityDataError):
+        Work(is_manifestation_data, plugin=mock_plugin)
+
+    manifestation_of_data = copy(work_data)
+    manifestation_of_data['manifestationOfWork'] = {}
+    with raises(EntityDataError):
+        Work(manifestation_of_data, plugin=mock_plugin)
 
 
 @mark.parametrize('data_format,model_data_name', [
@@ -160,7 +176,7 @@ def test_manifestation_init_with_type(mock_plugin, manifestation_data_factory,
     assert manifestation.to_jsonld() == manifestation_jsonld
 
 
-def test_manifestation_init_raise_without_manifestation_of(
+def test_manifestation_init_raises_without_manifestation_of(
         mock_plugin, manifestation_data_factory):
     from coalaip.models import Manifestation
     from coalaip.exceptions import EntityDataError
@@ -215,8 +231,8 @@ def test_copyright_init(mock_plugin, copyright_data_factory,
     assert copyright.to_jsonld() == copyright_jsonld
 
 
-def test_copyright_init_raise_without_rights_of(mock_plugin,
-                                                copyright_data_factory):
+def test_copyright_init_raises_without_rights_of(mock_plugin,
+                                                 copyright_data_factory):
     from coalaip.models import Copyright
     from coalaip.exceptions import EntityDataError
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,9 @@
+from unittest.mock import Mock
+
+
+def create_mock_plugin():
+    mock_plugin = Mock(
+        name="mock_ledger_plugin",
+        spec_set=['create_user', 'get_status', 'save', 'transfer', 'type'])
+    mock_plugin.type = 'mock'
+    return mock_plugin

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,6 @@ from unittest.mock import Mock
 def create_mock_plugin():
     mock_plugin = Mock(
         name="mock_ledger_plugin",
-        spec_set=['create_user', 'get_status', 'save', 'transfer', 'type'])
+        spec_set=['generate_user', 'get_status', 'save', 'transfer', 'type'])
     mock_plugin.type = 'mock'
     return mock_plugin

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,10 @@
 from unittest.mock import Mock
+from coalaip.plugin import AbstractPlugin
 
 
 def create_mock_plugin():
     mock_plugin = Mock(
         name="mock_ledger_plugin",
-        spec_set=['generate_user', 'get_status', 'save', 'transfer', 'type'])
+        spec_set=AbstractPlugin)
     mock_plugin.type = 'mock'
     return mock_plugin

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,3 +8,21 @@ def create_mock_plugin():
         spec_set=AbstractPlugin)
     mock_plugin.type = 'mock'
     return mock_plugin
+
+
+def create_entity_id_setter(work_id, manifestation_id, copyright_id,
+                            type_key='@type'):
+    def set_entity_id(entity_data, *args, **kwargs):
+        if entity_data.get('isManifestation', False):
+            return manifestation_id
+        elif entity_data[type_key] == 'CreativeWork':
+            return work_id
+        elif entity_data[type_key] == 'Copyright':
+            return copyright_id
+    return set_entity_id
+
+
+def assert_key_values_present_in_dict(check_dict, **kwargs):
+    from functools import reduce
+    assert reduce(lambda present, k: present and check_dict.get(k) == kwargs[k],
+                  kwargs, True)

--- a/tox.ini
+++ b/tox.ini
@@ -4,16 +4,17 @@ envlist = py34, py35, flake8
 [testenv:flake8]
 basepython=python
 deps=flake8
-commands=flake8 coalaip
+commands=flake8 coalaip tests
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/coalaip
 deps =
     -r{toxinidir}/requirements_dev.txt
+install_command = pip install --process-dependency-links {opts} {packages}
 commands =
     pip install -U pip
-    py.test --basetemp={envtmpdir}
+    py.test -v --cov=coalaip --basetemp={envtmpdir}
 
 
 ; If you want to make tox run the tests with the same versions, create a

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
 install_command = pip install --process-dependency-links {opts} {packages}
 commands =
     pip install -U pip
-    py.test -v --cov=coalaip --basetemp={envtmpdir}
+    pytest -v --cov=coalaip --basetemp={envtmpdir}
 
 
 ; If you want to make tox run the tests with the same versions, create a


### PR DESCRIPTION
Fixes #3 and #4.

Depends on #8, but changes there will be rebased onto here as necessary.

Implements:

- COALA IP models
- COALA IP creation functionality
- Plugin discovery, ala `setuptool`'s entry points
- Tests for the above with a mocked plugin

TODO:

- [x] Handle error cases
- [ ] Add more `docs/` documentation