### PR TITLE
Use Rights model as base class of derived Rights

### DIFF
--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -283,6 +283,8 @@ class Work(Creation):
                 Must not include keys that indicate the model is a
                 :class:`~coalaip.models.Manifestation` (e.g.
                 ``manifestationOfWork`` or ``isManifestation == True``).
+                See :class:`~pycoalaip.models.Creation` for other model
+                requirements.
             *args: see :class:`~coalaip.models.CoalaIpEntity`
             **kwargs: see :class:`~coalaip.models.CoalaIpEntity`
 
@@ -316,9 +318,12 @@ class Manifestation(Creation):
         Args:
             data (dict): a dict holding the model data for the
                 Manifestation. Must include a ``manifestationOfWork``
-                key. If an ``type`` or ``@type`` key is provided in the
+                key.
+                If an ``type`` or ``@type`` key is provided in the
                 'data', this type will be used as the ``entity_type``
                 rather than the 'entity_type' keyword argument.
+                See :class:`~pycoalaip.models.Creation` for other model
+                requirements.
             entity_type (str, keyword, optional): the "@type" of the
                 Manifestation.
                 Defaults to 'CreativeWork'.
@@ -455,6 +460,8 @@ class Copyright(Right):
         Args:
             data (dict): a dict holding the model data for the
                 Copyright. Must include at least a ``rightsOf`` key.
+                See :class:`~pycoalaip.models.Right` for other model
+                requirements.
             *args: see :class:`~coalaip.models.CoalaIpEntity`
             **kwargs: see :class:`~coalaip.models.CoalaIpEntity`
 

--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -444,22 +444,6 @@ class Copyright(Right):
         super().__init__(data, entity_type='Copyright', *args, **kwargs)
 
 
-class GenericDerivedRight(Right):
-    """
-    TODO
-    """
-
-    def __init__(self, data, *args, entity_type='GenericDerivedRight',
-                 **kwargs):
-        """Initialize a :class:`~coalaip.models.GenericDerivedRight`
-        instance
-
-        TODO
-        """
-
-        super().__init__(data, entity_type=entity_type, *args, **kwargs)
-
-
 class RightsAssignment(CoalaIpEntity):
     """COALA IP's RightsAssignment entity.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,6 +184,50 @@ def mock_copyright_create_id():
 
 
 @fixture
+def right_data_factory(mock_copyright_create_id):
+    def factory(*, allowedBy=mock_copyright_create_id, data=None):
+        right_data = {
+            'allowedBy': allowedBy
+        }
+        return extend_dict(right_data, data)
+    return factory
+
+
+@fixture
+def right_jsonld_factory(right_data_factory):
+    def factory(**kwargs):
+        ld_data = {
+            '@context': COALAIP,
+            '@type': 'Right',
+            '@id': '',
+        }
+        return extend_dict(ld_data, right_data_factory(**kwargs))
+    return factory
+
+
+@fixture
+def right_json_factory(right_data_factory):
+    def factory(**kwargs):
+        json_data = {
+            'type': 'Right',
+        }
+        return extend_dict(json_data, right_data_factory(**kwargs))
+    return factory
+
+
+@fixture
+def right_model(mock_plugin, right_data_factory):
+    from coalaip.models import Right
+    right_data = right_data_factory()
+    return Right(right_data, plugin=mock_plugin)
+
+
+@fixture
+def mock_right_create_id():
+    return 'mock_right_create_id'
+
+
+@fixture
 def transfer_contract_url():
     return 'https://ipdb.s3.amazonaws.com/1234567890.pdf'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,11 +123,9 @@ def manifestation_json_factory(manifestation_data_factory):
 
 
 @fixture
-def manifestation_model(mock_plugin, manifestation_data_factory,
-                        mock_work_create_id):
+def manifestation_model(mock_plugin, manifestation_data_factory):
     from coalaip.models import Manifestation
-    manifestation_data = manifestation_data_factory(
-        manifestationOfWork=mock_work_create_id)
+    manifestation_data = manifestation_data_factory()
     return Manifestation(manifestation_data, plugin=mock_plugin)
 
 
@@ -174,11 +172,9 @@ def copyright_json_factory(copyright_data_factory):
 
 
 @fixture
-def copyright_model(mock_plugin, copyright_data_factory,
-                    mock_manifestation_create_id):
+def copyright_model(mock_plugin, copyright_data_factory):
     from coalaip.models import Copyright
-    copyright_data = copyright_data_factory(
-        rightsOf=mock_manifestation_create_id)
+    copyright_data = copyright_data_factory()
     return Copyright(copyright_data, plugin=mock_plugin)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -220,14 +220,18 @@ def test_manifestation_init_raises_if_no_name(mock_plugin,
         Manifestation(manifestation_data, plugin=mock_plugin)
 
 
-def test_manifestation_init_raises_without_manifestation_of(
+def test_manifestation_init_raises_without_str_manifestation_of(
         mock_plugin, manifestation_data_factory):
     from coalaip.models import Manifestation
     from coalaip.exceptions import EntityDataError
 
     manifestation_data = manifestation_data_factory()
-    del manifestation_data['manifestationOfWork']
 
+    del manifestation_data['manifestationOfWork']
+    with raises(EntityDataError):
+        Manifestation(manifestation_data, plugin=mock_plugin)
+
+    manifestation_data['manifestationOfWork'] = {}
     with raises(EntityDataError):
         Manifestation(manifestation_data, plugin=mock_plugin)
 
@@ -365,25 +369,34 @@ def test_copyright_transferrable(mock_plugin, alice_user, bob_user,
                                             to_user=bob_user)
 
 
-def test_right_init_raises_without_allowed_by(mock_plugin, right_data_factory):
+def test_right_init_raises_without_str_allowed_by(mock_plugin,
+                                                  right_data_factory):
     from coalaip.models import Right
     from coalaip.exceptions import EntityDataError
 
-    right_data = right_data_factory(allowedBy='')
-    del right_data['allowedBy']
+    right_data = right_data_factory()
 
+    del right_data['allowedBy']
+    with raises(EntityDataError):
+        Right(right_data, plugin=mock_plugin)
+
+    right_data['allowedBy'] = {}
     with raises(EntityDataError):
         Right(right_data, plugin=mock_plugin)
 
 
-def test_copyright_init_raises_without_rights_of(mock_plugin,
-                                                 copyright_data_factory):
+def test_copyright_init_raises_without_str_rights_of(mock_plugin,
+                                                     copyright_data_factory):
     from coalaip.models import Copyright
     from coalaip.exceptions import EntityDataError
 
-    copyright_data = copyright_data_factory(rightsOf='')
-    del copyright_data['rightsOf']
+    copyright_data = copyright_data_factory()
 
+    del copyright_data['rightsOf']
+    with raises(EntityDataError):
+        Copyright(copyright_data, plugin=mock_plugin)
+
+    copyright_data['rightsOf'] = {}
     with raises(EntityDataError):
         Copyright(copyright_data, plugin=mock_plugin)
 


### PR DESCRIPTION
Removes unnecessary GenericDerivedRight model and adds tests for using Rights.