### PR TITLE
Make resulting copyright holder more explicit in Manifestation registration

### DIFF
--- a/coalaip/coalaip.py
+++ b/coalaip/coalaip.py
@@ -57,7 +57,7 @@ class CoalaIp:
         return self._plugin.generate_user(*args, **kwargs)
 
     # TODO: could probably have a 'safe' check to make sure the entities are actually created
-    def register_manifestation(self, manifestation_data, *, user,
+    def register_manifestation(self, manifestation_data, *, copyright_holder,
                                existing_work=None, work_data=None, **kwargs):
         """Register a Manifestation and automatically assign its
         corresponding Copyright to the given :attr:`user`.
@@ -72,8 +72,10 @@ class CoalaIp:
                 If ``manifestationOfWork`` is provided in the dict, the
                 :attr:`existing_work` and :attr:`work_data` parameters are
                 ignored and no Work is registered.
-            user (any, keyword): A user based on the format specified by
-                the persistence layer
+            copyright_holder (any, keyword): The user to hold the
+                corresponding Copyright of the registered Manifestation;
+                should be specified in the format required by the
+                persistence layer
             existing_work (:class:`~.Work`, keyword, optional): An
                 already persisted Work that the Manifestation is derived
                 from.
@@ -127,7 +129,7 @@ class CoalaIp:
                 if work_data is None:
                     work_data = {'name': manifestation_data.get('name')}
                 work = Work.from_data(work_data, plugin=self._plugin)
-                work.create(user, **kwargs)
+                work.create(copyright_holder, **kwargs)
             elif not isinstance(existing_work, Work):
                 raise TypeError(("'existing_work' argument to "
                                  "'register_manifestation()' must be a Work. "
@@ -144,12 +146,12 @@ class CoalaIp:
 
         manifestation = Manifestation.from_data(manifestation_data,
                                                 plugin=self._plugin)
-        manifestation.create(user, **kwargs)
+        manifestation.create(copyright_holder, **kwargs)
 
         copyright_data = {'rightsOf': manifestation.persist_id}
         manifestation_copyright = Copyright.from_data(copyright_data,
                                                       plugin=self._plugin)
-        manifestation_copyright.create(user, **kwargs)
+        manifestation_copyright.create(copyright_holder, **kwargs)
 
         return RegistrationResult(manifestation_copyright, manifestation, work)
 
@@ -166,8 +168,8 @@ class CoalaIp:
                 If ``allowedBy`` is provided in the dict, the
                 :attr:`source_right` parameter is ignored.
             current_holder (any, keyword): The current holder of the
-                :attr:`source_right`; a user based on the format
-                specified by the persistence layer
+                :attr:`source_right`; should be specified in the format
+                required by the persistence layer
             source_right (:class:`~.Right`, keyword, optional): An
                 already persisted Right that the new Right is allowed by.
                 Optional if ``allowedBy`` is provided in :attr:`right_data`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -378,5 +378,5 @@ def persisted_jsonld_registration(mock_plugin, mock_coalaip,
 
     return mock_coalaip.register_manifestation(
         manifestation_data,
-        user=alice_user,
+        copyright_holder=alice_user,
     )

--- a/tests/test_coalaip.py
+++ b/tests/test_coalaip.py
@@ -65,7 +65,7 @@ def test_register_manifestation(mock_plugin, mock_coalaip, manifestation_data,
     # Create the entities and test they contain the right links
     manifestation_copyright, manifestation, work = mock_coalaip.register_manifestation(
         manifestation_data,
-        user=alice_user,
+        copyright_holder=alice_user,
         **register_manifestation_kwargs,
     )
     assert manifestation_copyright.data['rightsOf'] == manifestation.persist_id
@@ -127,7 +127,7 @@ def test_register_manifestation_with_work_id_in_data(
 
     manifestation_copyright, manifestation, work = mock_coalaip.register_manifestation(
         manifestation_data,
-        user=alice_user,
+        copyright_holder=alice_user,
         existing_work=ignored_work_entity,
     )
     assert work is None
@@ -158,7 +158,7 @@ def test_register_manifestation_with_work_data(
     # Create the entities
     manifestation_copyright, manifestation, work = mock_coalaip.register_manifestation(
         manifestation_data,
-        user=alice_user,
+        copyright_holder=alice_user,
         work_data=work_data,
     )
     assert manifestation_copyright.data['rightsOf'] == manifestation.persist_id
@@ -200,7 +200,7 @@ def test_register_manifestation_with_existing_work(
     mock_plugin.reset_mock()  # Reset call counts on the mock from before
     new_manifestation_copyright, new_manifestation, old_work = mock_coalaip.register_manifestation(
         manifestation_data,
-        user=alice_user,
+        copyright_holder=alice_user,
         existing_work=persisted_jsonld_registration.work,
         work_data={'ignored': 'ignored'},
     )
@@ -236,7 +236,7 @@ def test_register_manifestation_with_existing_work_raises_on_non_work(
     with raises(TypeError):
         mock_coalaip.register_manifestation(
             manifestation_data,
-            user=alice_user,
+            copyright_holder=alice_user,
             existing_work={},
         )
 
@@ -250,7 +250,7 @@ def test_register_manifestation_with_existing_work_raises_on_unpersisted_work(
     with raises(EntityNotYetPersistedError):
         mock_coalaip.register_manifestation(
             manifestation_data,
-            user=alice_user,
+            copyright_holder=alice_user,
             existing_work=work_entity,
         )
 
@@ -263,7 +263,7 @@ def test_register_manifestation_raises_on_creation_error(
 
     with raises(EntityCreationError):
         mock_coalaip.register_manifestation(manifestation_data,
-                                            user=alice_user)
+                                            copyright_holder=alice_user)
 
 
 @mark.parametrize('use_data_format_enum', [True, False])


### PR DESCRIPTION
Some small API changes that will also affect github.com/bigchaindb/coalaip-http-api.

Also had a thought that, instead of always registering the Work and Manifestation for the given user, a user could be provided with the plugin to be used when registering these "ownership-less" assets. For example, DACS could provide their own account to hold these assets while only the Rights go to the actual end user.

Thoughts @TimDaub?