### PR TITLE
Use strict checks for `persist_id` and only access through read-only property

### DIFF
--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -134,12 +134,13 @@ class CoalaIpEntity:
                 the existing id of the entity on the persistence layer.
         """
 
-        if self._persist_id:
+        if self.persist_id:
             raise EntityPreviouslyCreatedError(self._persist_id)
 
         entity_data = self._to_format(data_format)
-        self._persist_id = self._plugin.save(entity_data, user=user)
-        return self._persist_id
+        create_id = self._plugin.save(entity_data, user=user)
+        self._persist_id = create_id
+        return create_id
 
     def get_status(self):
         """Get the current status of this entity, including it's state
@@ -155,9 +156,9 @@ class CoalaIpEntity:
                 persistence layer
         """
 
-        if self._persist_id is None:
+        if self.persist_id is None:
             return None
-        return self._plugin.get_status(self._persist_id)
+        return self._plugin.get_status(self.persist_id)
 
     def to_json(self):
         """Output this entity as a JSON-serializable dict.
@@ -233,9 +234,9 @@ class CoalaIpTransferrableEntity(CoalaIpEntity):
         if self._persist_id is None:
             raise EntityNotYetPersistedError(('Entities cannot be transferred '
                                               'until they have been persisted'))
-        else:
-            return self._plugin.transfer(self._persist_id, transfer_payload,
-                                         from_user=from_user, to_user=to_user)
+
+        return self._plugin.transfer(self.persist_id, transfer_payload,
+                                     from_user=from_user, to_user=to_user)
 
 
 class Creation(CoalaIpEntity):

--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -77,8 +77,14 @@ class CoalaIpEntity:
         self._plugin = plugin
 
     def __repr__(self):
-        return "{name}: {data}".format(name=self.__class__.__name__,
-                                       data=self.data)
+        persist_str = ', {plugin}@{persist_id}'.format(
+            plugin=self.plugin_type,
+            persist_id=self.persist_id
+        ) if self.persist_id else ''
+
+        return '{name}{persist}: {data}'.format(name=self.__class__.__name__,
+                                                persist=persist_str,
+                                                data=self.data)
 
     @property
     def data(self):

--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -80,7 +80,7 @@ class CoalaIpEntity:
         persist_str = ', {plugin}@{persist_id}'.format(
             plugin=self.plugin_type,
             persist_id=self.persist_id
-        ) if self.persist_id else ''
+        ) if self.persist_id is not None else ''
 
         return '{name}{persist}: {data}'.format(name=self.__class__.__name__,
                                                 persist=persist_str,
@@ -134,7 +134,7 @@ class CoalaIpEntity:
                 the existing id of the entity on the persistence layer.
         """
 
-        if self.persist_id:
+        if self.persist_id is not None:
             raise EntityPreviouslyCreatedError(self._persist_id)
 
         entity_data = self._to_format(data_format)
@@ -231,7 +231,7 @@ class CoalaIpTransferrableEntity(CoalaIpEntity):
                 persisted to the backing persistence layer
         """
 
-        if self._persist_id is None:
+        if self.persist_id is None:
             raise EntityNotYetPersistedError(('Entities cannot be transferred '
                                               'until they have been persisted'))
 


### PR DESCRIPTION
Also adds the persistence information to a model's REPL output.