### PR TITLE
Add sanity check for interoperable models

### DIFF
--- a/coalaip/exceptions.py
+++ b/coalaip/exceptions.py
@@ -49,10 +49,10 @@ class ModelError(Exception):
     """Base class for all model errors."""
 
 
-class ModelDataError(EntityError, ValueError):
+class ModelDataError(ModelError, ValueError):
     """Raised if there is an error with the model's data"""
 
 
-class ModelNotYetLoadedError(EntityError):
+class ModelNotYetLoadedError(ModelError):
     """Raised if the lazily loaded model has not been loaded from the
     backing persistence layer yet."""

--- a/coalaip/exceptions.py
+++ b/coalaip/exceptions.py
@@ -1,7 +1,12 @@
 """Custom exceptions for COALA IP"""
 
 
-class EntityError(Exception):
+class CoalaIpError(Exception):
+    """Base class for all Coala IP errors.
+    """
+
+
+class EntityError(CoalaIpError):
     """Base class for all entity errors."""
 
 
@@ -13,8 +18,8 @@ class EntityCreationError(EntityError):
 
     @property
     def error(self):
-        """Original error that caused the creation of the entity on the
-        persistence layer to fail
+        """:exc:`Exception`: Original error that caused the creation of
+        the entity on the persistence layer to fail
         """
         return self.args[0]
 
@@ -39,13 +44,27 @@ class EntityPreviouslyCreatedError(EntityError):
 
     @property
     def existing_id(self):
-        """Currently existing ID of the entity on the persistence
-        layer.
+        """:obj:`str:` Currently existing ID of the entity on the
+        persistence layer.
         """
         return self.args[0]
 
 
-class ModelError(Exception):
+class IncompatiblePluginError(CoalaIpError):
+    """Raised when entities with incompatible plugins are used together.
+    Should contain a list of the incompatible plugins as the first
+    argument.
+    """
+
+    @property
+    def incompatible_plugins(self):
+        """:obj:`list` of :class:`~coalaip.plugin.AbstractPlugin`:
+        Incompatible plugins
+        """
+        return self.args[0]
+
+
+class ModelError(CoalaIpError):
     """Base class for all model errors."""
 
 


### PR DESCRIPTION
Adds a check to make sure that passed in models are of the same plugin as the CoalaIp instance. Right now, it doesn't make much sense if the entities don't live on the same persistence layer (ie. same BigchainDB instance), but in the future, plugins might be able to expose a way to create a "canonical" purl for other persistence layers to use.