### PR TITLE
Handle generic plugin errors

### DIFF
--- a/coalaip/__init__.py
+++ b/coalaip/__init__.py
@@ -5,3 +5,5 @@ __version__ = '0.0.1.dev2'
 from coalaip.coalaip import (  # noqa
     CoalaIp
 )
+
+from coalaip.exceptions import *  # noqa

--- a/coalaip/coalaip.py
+++ b/coalaip/coalaip.py
@@ -48,13 +48,18 @@ class CoalaIp:
         """Generate a new user for the backing persistence layer.
 
         Args:
-            *args: argument list passed to the plugin's generate_user()
-            **kwargs: keyword arguments passed to the plugin's
+            *args: Argument list passed to the plugin's
+                ``generate_user()``
+            **kwargs: Keyword arguments passed to the plugin's
                 ``generate_user()``
 
         Returns:
-            a representation of a user, based on the persistence layer
+            A representation of a user, based on the persistence layer
             plugin
+
+        Raises:
+            :exc:`~.PersistenceError`: If a user couldn't be generated
+                on the persistence layer
         """
 
         return self._plugin.generate_user(*args, **kwargs)
@@ -115,15 +120,17 @@ class CoalaIp:
             :exc:`~.ModelDataError`: If the :attr:`manifestation_data`
                 or :attr:`work_data` contain invalid or are missing
                 required properties.
-            :exc:`~.EntityNotYetPersistedError`: if the
+            :class:`~.IncompatiblePluginError`: If the
+                :attr:`existing_work` is not using a compatible plugin
+            :exc:`~.EntityNotYetPersistedError`: If the
                 :attr:`existing_work` is not associated with an id on the
                 persistence layer (:attr:`~.Entity.persist_id`) yet
-            :exc:`~.EntityCreationError`: if the manifestation, its
+            :exc:`~.EntityCreationError`: If the manifestation, its
                 copyright, or the automatically created work (if no
                 existing work is given) fail to be created on the
                 persistence layer
-            :class:`~.IncompatiblePluginError`: If the
-                :attr:`existing_work` is not using a compatible plugin
+            :exc:`~.PersistenceError`: If any other error occurred with
+                the persistence layer
         """
 
         # TODO: in the future, we may want to consider blocking (or asyncing) until
@@ -202,11 +209,13 @@ class CoalaIp:
         Raises:
             :exc:`~.ModelDataError`: If the :attr:`right_data`
                 contains invalid or is missing required properties.
-            :exc:`~.EntityNotYetPersistedError`: if the
+            :exc:`~.EntityNotYetPersistedError`: If the
                 :attr:`source_right` is not associated with an id on the
                 persistence layer (:attr:`~.Entity.persist_id`) yet
-            :exc:`~.EntityCreationError`: if the Right fails to be
+            :exc:`~.EntityCreationError`: If the Right fails to be
                 created on the persistence layer
+            :exc:`~.PersistenceError`: If any other error occurred with
+                the persistence layer
         """
 
         # TODO: add validation that the `current_user` is actually the holder
@@ -263,10 +272,14 @@ class CoalaIp:
             associated with this transfer
 
         Raises:
-            :exc:`~.EntityNotYetPersistedError`: if the :attr:`right`
+            :exc:`~.EntityNotYetPersistedError`: If the :attr:`right`
                 has not been persisted yet
-            :exc:`~.EntityTransferError`: if the :attr:`right` fails to
+            :exc:`~.EntityNotFoundError`: If the :attr:`right` was not
+                found on the persistence layer
+            :exc:`~.EntityTransferError`: If the :attr:`right` fails to
                 be transferred on the persistence layer
+            :exc:`~.PersistenceError`: If any other error occurred with
+                the persistence layer
         """
 
         if not isinstance(right, Right):

--- a/coalaip/entities.py
+++ b/coalaip/entities.py
@@ -274,6 +274,8 @@ class Entity(ABC, PostInitImmutable):
             :exc:`~.EntityPreviouslyCreatedError`: If the entity has
                 already been persisted. Contains the existing id of the
                 entity on the persistence layer.
+            :exc:`~.PersistenceError`: If any other unhandled error
+                in the plugin occurred
         """
 
         if self.persist_id is not None:
@@ -299,6 +301,8 @@ class Entity(ABC, PostInitImmutable):
             :exc:`~.EntityNotFoundError`: If the entity has a
                 :attr:`~Entity.persist_id` but could not be found on
                 the persistence layer
+            :exc:`~.PersistenceError`: If any other unhandled error
+                in the plugin occurred
             :exc:`~.ModelDataError`: If the loaded entity's data fails
                 validation or its type or context differs from their
                 expected values
@@ -380,8 +384,12 @@ class TransferrableEntity(Entity):
             :exc:`~.EntityNotYetPersistedError`: If the entity being
                 transferred is not associated with an id on the
                 persistence layer (:attr:`~Entity.persist_id`) yet
+            :exc:`~.EntityNotFoundError`: If the entity could not be
+                found on the persistence layer
             :exc:`~.EntityTransferError`: If the entity fails to be
                 transferred on the persistence layer
+            :exc:`~.PersistenceError`: If any other unhandled error
+                in the plugin occurred
         """
 
         if self.persist_id is None:

--- a/coalaip/entities.py
+++ b/coalaip/entities.py
@@ -25,10 +25,10 @@ from coalaip.data_formats import (
     _extract_ld_data,
 )
 from coalaip.exceptions import (
-    EntityError,
     EntityNotYetPersistedError,
     EntityPreviouslyCreatedError,
     ModelNotYetLoadedError,
+    PersistenceError,
 )
 from coalaip.models import (
     Model,
@@ -531,10 +531,10 @@ class RightsAssignment(Entity):
 
     def create(self, *args, **kwargs):
         """Removes the ability to persist a :class:`~.RightsAssignment`
-        normally. Raises :exc:`~.EntityError` if called.
+        normally. Raises :exc:`~.PersistenceError` if called.
         """
-        raise EntityError(('RightsAssignments can only be created through '
-                           'transer transactions.'))
+        raise PersistenceError(('RightsAssignments can only be created '
+                                ' through transer transactions.'))
 
     @classmethod
     def generate_model(cls, *args, **kwargs):

--- a/coalaip/exceptions.py
+++ b/coalaip/exceptions.py
@@ -2,69 +2,10 @@
 
 
 class CoalaIpError(Exception):
-    """Base class for all Coala IP errors.
-    """
+    """Base class for all Coala IP errors."""
 
 
-class EntityError(CoalaIpError):
-    """Base class for all entity errors."""
-
-
-class EntityCreationError(EntityError):
-    """Raised if an error occured during the creation of an entity.
-    Should contain the original error that caused the failure as the
-    first argument, if available.
-    """
-
-    @property
-    def error(self):
-        """:exc:`Exception`: Original error that caused the creation of
-        the entity on the persistence layer to fail
-        """
-        return self.args[0]
-
-
-class EntityNotFoundError(EntityError):
-    """Raised if the entity could not be found on the backing persistence
-    layer
-    """
-
-
-class EntityNotYetPersistedError(EntityError):
-    """Raised when an action requiring an entity to be available on the
-    persistence layer is attempted on an entity that has not been
-    persisted yet
-    """
-
-
-class EntityPreviouslyCreatedError(EntityError):
-    """Raised when attempting to persist an already persisted entity.
-    Should contain the existing id of the entity as the first argument.
-    """
-
-    @property
-    def existing_id(self):
-        """:obj:`str:` Currently existing ID of the entity on the
-        persistence layer.
-        """
-        return self.args[0]
-
-
-class EntityTransferError(EntityError):
-    """Raised if an error occured during the transfer of an entity.
-    Should contain the original error that caused the failure as the
-    first argument, if available.
-    """
-
-    @property
-    def error(self):
-        """:exc:`Exception`: Original error that caused the transfer of
-        the entity on the persistence layer to fail
-        """
-        return self.args[0]
-
-
-class IncompatiblePluginError(CoalaIpError):
+class IncompatiblePluginError(CoalaIpError, ValueError):
     """Raised when entities with incompatible plugins are used together.
     Should contain a list of the incompatible plugins as the first
     argument.
@@ -83,9 +24,69 @@ class ModelError(CoalaIpError):
 
 
 class ModelDataError(ModelError, ValueError):
-    """Raised if there is an error with the model's data"""
+    """Raised if there is an error with the model's data."""
 
 
 class ModelNotYetLoadedError(ModelError):
     """Raised if the lazily loaded model has not been loaded from the
     backing persistence layer yet."""
+
+
+class PersistenceError(CoalaIpError):
+    """Base class for all persistence-related errors.
+
+    Attributes:
+        message (str): Message of the error
+        error (:exc:`Exception`): Original exception, if available
+    """
+
+    def __init__(self, message='', error=None):
+        self.message = message
+        self.error = error
+
+    def __str__(self):
+        return self.message
+
+
+class EntityCreationError(PersistenceError):
+    """Raised if an error occured during the creation of an entity on the
+    backing persistence layer.
+    Should contain the original error that caused the failure, if
+    available.
+    """
+
+
+class EntityNotFoundError(PersistenceError):
+    """Raised if the entity could not be found on the backing persistence
+    layer
+    """
+
+
+class EntityNotYetPersistedError(PersistenceError):
+    """Raised when an action requiring an entity to be available on the
+    persistence layer is attempted on an entity that has not been
+    persisted yet.
+    """
+
+
+class EntityPreviouslyCreatedError(PersistenceError):
+    """Raised when attempting to persist an already persisted entity.
+    Should contain the existing id of the entity.
+
+    Attributes:
+        existing_id (str): Currently existing id of the entity on the
+            persistence layer
+        See :exc:`.PersistenceError` for other attributes.
+    """
+
+    def __init__(self, existing_id, *args, **kwargs):
+        self.existing_id = existing_id
+        super().__init__(*args, **kwargs)
+
+
+class EntityTransferError(PersistenceError):
+    """Raised if an error occured during the transfer of an entity on the
+    backing persistence layer.
+    Should contain the original error that caused the failure, if
+    available.
+    """

--- a/coalaip/models.py
+++ b/coalaip/models.py
@@ -158,6 +158,10 @@ class LazyLoadableModel(PostInitImmutable):
                 validation from :attr:`~.LazyLoadableEntity.validator`
                 or its type or context differs from their expected
                 values
+            :exc:`~.EntityNotFoundError`: If the entity could not be
+                found on the persistence layer
+            :exc:`~.PersistenceError`: If any other unhandled error
+                in the plugin occurred
         """
         if self.loaded_model:
             return

--- a/coalaip/plugin.py
+++ b/coalaip/plugin.py
@@ -27,6 +27,10 @@ class AbstractPlugin(ABC):
         Returns:
             A representation of a user (e.g. a tuple with the user's
             public and private keypair) on the persistence layer
+
+        Raises:
+            :exc:`~.PersistenceError`: If any other unhandled error
+                in the plugin occurred
         """
 
     @abstractmethod
@@ -42,6 +46,8 @@ class AbstractPlugin(ABC):
         Raises:
             :exc:`~.EntityNotFoundError`: If the entity could not be
                 found on the persistence layer
+            :exc:`~.PersistenceError`: If any other unhandled error
+                in the plugin occurred
         """
 
     @abstractmethod
@@ -60,6 +66,8 @@ class AbstractPlugin(ABC):
         Raises:
             :exc:`~..EntityCreationError`: If the entity failed to be
                 created
+            :exc:`~.PersistenceError`: If any other unhandled error
+                in the plugin occurred
         """
 
     @abstractmethod
@@ -75,6 +83,8 @@ class AbstractPlugin(ABC):
         Raises:
             :exc:`~.EntityNotFoundError`: If the entity could not be
                 found on the persistence layer
+            :exc:`~.PersistenceError`: If any other unhandled error
+                in the plugin occurred
         """
 
     @abstractmethod
@@ -92,4 +102,12 @@ class AbstractPlugin(ABC):
 
         Returns:
             str: Id of the transfer action on the persistence layer
+
+        Raises:
+            :exc:`~.EntityNotFoundError`: If the entity could not be
+                found on the persistence layer
+            :exc:`~..EntityTransferError`: If the entity failed to be
+                transferred
+            :exc:`~.PersistenceError`: If any other unhandled error
+                in the plugin occurred
         """

--- a/docs/libref.rst
+++ b/docs/libref.rst
@@ -84,7 +84,17 @@ prefer one of the :ref:`core-entities` instead.
 
 .. automodule:: coalaip.exceptions
 
-.. autoclass:: EntityError
+.. autoclass:: CoalaIpError
+
+.. autoclass:: IncompatiblePluginError
+
+.. autoclass:: ModelError
+
+.. autoclass:: ModelDataError
+
+.. autoclass:: ModelNotYetLoadedError
+
+.. autoclass:: PersistenceError
 
 .. autoclass:: EntityCreationError
 
@@ -94,11 +104,7 @@ prefer one of the :ref:`core-entities` instead.
 
 .. autoclass:: EntityPreviouslyCreatedError
 
-.. autoclass:: ModelError
-
-.. autoclass:: ModelDataError
-
-.. autoclass:: ModelNotYetLoadedError
+.. autoclass:: EntityTransferError
 
 
 ``plugin``

--- a/docs/libref.rst
+++ b/docs/libref.rst
@@ -42,6 +42,9 @@ Library Reference
 .. autoclass:: Copyright
     :members:
 
+.. autoclass:: RightsAssignment
+    :members:
+
 ``Base Entities``
 ^^^^^^^^^^^^^^^^^
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,13 @@ def mock_creation_error():
 
 
 @fixture
+def mock_not_found_error():
+    from coalaip.exceptions import EntityNotFoundError
+    exception = EntityNotFoundError('mock_not_found_error')
+    return exception
+
+
+@fixture
 def mock_transfer_error():
     from coalaip.exceptions import EntityTransferError
     exception = EntityTransferError('mock_transfer_error',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,14 +67,16 @@ def mock_entity_context():
 @fixture
 def mock_creation_error():
     from coalaip.exceptions import EntityCreationError
-    exception = EntityCreationError(mock_creation_error)
+    exception = EntityCreationError('mock_creation_error',
+                                    error=Exception())
     return exception
 
 
 @fixture
 def mock_transfer_error():
     from coalaip.exceptions import EntityTransferError
-    exception = EntityTransferError(mock_transfer_error)
+    exception = EntityTransferError('mock_transfer_error',
+                                    error=Exception())
     return exception
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -672,8 +672,8 @@ def test_right_transfer_raises_if_not_persisted(alice_user, bob_user,
 
 
 def test_rights_assignment_cannot_create(rights_assignment_entity, alice_user):
-    from coalaip.exceptions import EntityError
-    with raises(EntityError):
+    from coalaip.exceptions import PersistenceError
+    with raises(PersistenceError):
         rights_assignment_entity.create(user=alice_user)
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -437,6 +437,22 @@ def test_entity_load_raises_if_not_persisted(mock_plugin, entity_cls_name):
         entity.load()
 
 
+@mark.parametrize('entity_cls_name', ALL_ENTITY_CLS)
+def test_entity_load_raises_on_load_error(mock_plugin, entity_cls_name,
+                                          mock_not_found_error,
+                                          mock_entity_create_id):
+    from coalaip.models import LazyLoadableModel
+    from coalaip.exceptions import EntityNotFoundError
+    entity_cls = get_entity_cls(entity_cls_name)
+    model = entity_cls.generate_model(model_cls=LazyLoadableModel)
+    entity = entity_cls(model, mock_plugin)
+    entity.persist_id = mock_entity_create_id
+
+    mock_plugin.load.side_effect = mock_not_found_error
+    with raises(EntityNotFoundError):
+        entity.load()
+
+
 @mark.parametrize('entity_name', ALL_ENTITIES)
 def test_entity_have_none_status_if_not_persisted(mock_plugin, entity_name,
                                                   request):


### PR DESCRIPTION
Removes `EntityError` in favour of `PersistenceError` so that generic exceptions can be thrown from the plugin.

Any plugin method can throw `PersistenceError` in the event of a unexpected error.

**Breaking changes:**
   - Removes `EntityError`, replaced by `PersistenceError`.