### PR TITLE
Rename `ref_id` to `event_id` in history query

### DIFF
--- a/coalaip/plugin.py
+++ b/coalaip/plugin.py
@@ -49,7 +49,7 @@ class AbstractPlugin(ABC):
                 {
                     'user': A representation of a user as specified by the
                             persistence layer (may omit secret details, e.g. private keys),
-                    'ref_id': A reference id for the ownership event (e.g. transfer id)
+                    'event_id': A reference id for the ownership event (e.g. transfer id)
                 }
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -468,10 +468,10 @@ def test_entity_current_owner(mock_plugin, alice_user, bob_user, entity_name,
     entity = request.getfixturevalue(entity_name)
     mock_history = [{
         'user': alice_user,
-        'ref_id': mock_entity_create_id,
+        'event_id': mock_entity_create_id,
     }, {
         'user': bob_user,
-        'ref_id': mock_entity_create_id,
+        'event_id': mock_entity_create_id,
     }]
 
     entity.persist_id = mock_entity_create_id
@@ -513,10 +513,10 @@ def test_entity_history(mock_plugin, alice_user, bob_user, entity_name,
     entity = request.getfixturevalue(entity_name)
     mock_history = [{
         'user': alice_user,
-        'ref_id': mock_entity_create_id,
+        'event_id': mock_entity_create_id,
     }, {
         'user': bob_user,
-        'ref_id': mock_entity_create_id,
+        'event_id': mock_entity_create_id,
     }]
 
     entity.persist_id = mock_entity_create_id


### PR DESCRIPTION
From https://github.com/bigchaindb/pycoalaip-bigchaindb/pull/18#discussion_r101008834.